### PR TITLE
Issue 20 fix location template

### DIFF
--- a/Sample_Data/UTK/short.volvoices.oai.mods.xml
+++ b/Sample_Data/UTK/short.volvoices.oai.mods.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2015-05-26T17:40:05Z</responseDate>
+  <request verb="ListRecords" set="volvoices" metadataPrefix="oai_mods">http://dpla.lib.utk.edu:8080/repox/OAIHandler</request>
+  <ListRecords>
+  <record>
+    <header>
+      <identifier>volvoices_3778</identifier>
+      <datestamp>2015-04-30T15:23:37Z</datestamp>
+      <setSpec>volvoices</setSpec>
+    </header>
+    <metadata>
+      <mods version="3.5" xmlns="http://www.loc.gov/mods/v3"
+        xmlns:iso20775="info:ofi/fmt:xml:xsd:iso20775" xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+        <identifier type="local">0092_000050_000261_0001</identifier>
+        <identifier type="filename">0092_000050_000261_0001.jp2</identifier>
+        <name>
+          <namePart>unknown</namePart>
+          <role>
+            <roleTerm authority="marcrelator" type="text"
+              valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
+          </role>
+        </name>
+        <titleInfo>
+          <title>Bridge Collapse in Unnamed County, Tennessee</title>
+        </titleInfo>
+        <typeOfResource>still image</typeOfResource>
+        <originInfo>
+          <dateCreated>1929</dateCreated>
+          <dateCreated encoding="edtf" keyDate="yes">1929</dateCreated>
+        </originInfo>
+        <physicalDescription>
+          <extent>1 digital image; 1 photograph</extent>
+          <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
+          <internetMediaType>image/jp2</internetMediaType>
+          <digitalOrigin>reformatted digital</digitalOrigin>
+        </physicalDescription>
+        <abstract>This photograph shows a bridge that has collapsed. It appears that the bridge
+          collapsed as a small semi-truck attempted to cross. The county and location where this
+          picture was taken are not given.</abstract>
+        <language>
+          <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+        </language>
+        <location>
+          <physicalLocation>Tennessee. Department of Transportation</physicalLocation>
+          <holdingExternal>
+            <holding
+              xsi:schemaLocation="info:ofi/fmt:xml:xsd:iso20775 http://www.loc.gov/standards/iso20775/N130_ISOholdings_v6_1.xsd">
+              <physicalAddress>
+                <text>City: Nashville</text>
+                <text>County: Davidson County</text>
+                <text>State: Tennessee</text>
+              </physicalAddress>
+            </holding>
+          </holdingExternal>
+        </location>
+        <subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85016829">
+          <topic>Bridges</topic>
+        </subject>
+        <subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85136758">
+          <topic>Traffic accidents</topic>
+        </subject>
+        <subject displayLabel="Broad Topics">
+          <topic>Transportation and Internal Improvements</topic>
+        </subject>
+        <subject displayLabel="Tennessee Social Studies K-12 Eras in American History">
+          <temporal>Era 7 - The Emergence of Modern America (1890-1930)</temporal>
+        </subject>
+        <relatedItem displayLabel="Project" type="host">
+          <titleInfo>
+            <title>Volunteer Voices</title>
+          </titleInfo>
+          <location>
+            <url>http://digital.lib.utk.edu/collections/volvoices</url>
+          </location>
+        </relatedItem>
+        <relatedItem displayLabel="Collection" type="host">
+          <titleInfo>
+            <title>Historical Transportation Photographs</title>
+          </titleInfo>
+        </relatedItem>
+        <accessCondition type="use and reproduction">May be protected by copyright. For more
+          information, contact Special Collections at special@utk.edu.</accessCondition>
+        <recordInfo>
+          <recordIdentifier>record_0092_000050_000261_0001</recordIdentifier>
+          <recordContentSource>University of Tennessee, Knoxville. Special
+            Collections</recordContentSource>
+          <languageOfCataloging>
+            <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+          </languageOfCataloging>
+          <recordOrigin>Created and edited in general conformance to MODS Guidelines (Version
+            3.5).</recordOrigin>
+          <recordCreationDate encoding="edtf">2008-04-07</recordCreationDate>
+          <recordChangeDate encoding="edtf">2015-03-23</recordChangeDate>
+          <recordChangeDate encoding="edtf">2015-03-31</recordChangeDate>
+          <recordChangeDate encoding="edtf">2015-04-01</recordChangeDate>
+        </recordInfo>
+        <location>
+          <url access="object in context" usage="primary display"
+            >http://digital.lib.utk.edu/collections/islandora/object/volvoices%3A3778</url>
+          <url access="preview"
+            >http://digital.lib.utk.edu/collections/islandora/object/volvoices%3A3778/datastream/TN/view</url>
+        </location>
+      </mods>
+    </metadata>
+  </record>
+  </ListRecords>
+</OAI-PMH>

--- a/XSLT/utkMODStoMODS.xsl
+++ b/XSLT/utkMODStoMODS.xsl
@@ -227,9 +227,4 @@
     <xsl:template match="mods:recordInfo">
         <xsl:copy copy-namespaces="no"><xsl:copy-of select="node()|@*" copy-namespaces="no"></xsl:copy-of></xsl:copy>
     </xsl:template>
-
-    <xsl:template match="mods:recordContentSource">
-
-    </xsl:template>
-    
 </xsl:stylesheet>

--- a/XSLT/utkMODStoMODS.xsl
+++ b/XSLT/utkMODStoMODS.xsl
@@ -30,7 +30,9 @@
             <xsl:apply-templates select="mods:name"/> <!-- not handing over unknowns to DLTN, though we do keep in UTK Islandora -->
             <xsl:apply-templates select="mods:physicalDescription/mods:form" mode="form2genre"/> <!-- DPLA genre is UTK form - UTK form being copied over -->
             <location>
-                <xsl:apply-templates select="mods:location/*"/> <!-- error with UTK oai feed making multiple location wrappers - merged here -->
+                <xsl:apply-templates select="mods:location/mods:physicalLocation"/>
+                <xsl:apply-templates select="mods:location/mods:url"/>
+                <xsl:apply-templates select="mods:location/mods:holdingExternal"/>
             </location>
         </mods>
     </xsl:template>
@@ -41,16 +43,19 @@
             <xsl:copy copy-namespaces="no"><xsl:copy-of select="node()" copy-namespaces="no"></xsl:copy-of></xsl:copy>
         </xsl:if>
     </xsl:template>
-    
-    <xsl:template match="mods:location/*">
-        <xsl:copy copy-namespaces="no"><xsl:copy-of select="mods:physicalLocation" copy-namespaces="no"></xsl:copy-of></xsl:copy>
-        <xsl:template match="mods:url[@access='object in context']">
-        <url access="object in context" usage="primary display"
-            >http://digital.lib.utk.edu/collections/islandora/object/volvoices%3A3778</url>
-        <url access="preview"
-            >http://digital.lib.utk.edu/collections/islandora/object/volvoices%3A3778/datastream/TN/view</url>
+
+    <!-- templates for new mods:location -->
+    <xsl:template match="mods:location/mods:physicalLocation">
+        <xsl:copy-of select="." copy-namespaces="no"/>
     </xsl:template>
-    
+    <xsl:template match="mods:location/mods:url">
+        <!-- doesn't work - location is ordered -->
+        <xsl:copy-of select="." copy-namespaces="no"/>
+    </xsl:template>
+    <xsl:template match="mods:location/mods:holdingExternal">
+        <xsl:copy-of select="." copy-namespaces="no"/>
+    </xsl:template>
+
     <xsl:template match="mods:originInfo">
         <xsl:copy copy-namespaces="no"><xsl:copy-of select="mods:dateCreated[@encoding='edtf']" copy-namespaces="no"></xsl:copy-of></xsl:copy>
     </xsl:template>
@@ -221,6 +226,10 @@
     
     <xsl:template match="mods:recordInfo">
         <xsl:copy copy-namespaces="no"><xsl:copy-of select="node()|@*" copy-namespaces="no"></xsl:copy-of></xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="mods:recordContentSource">
+
     </xsl:template>
     
 </xsl:stylesheet>


### PR DESCRIPTION
**GitHub Issue: [Issue 20](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/20)
## What does this Pull Request do?
This PR addresses some malformed XML in utkMODStoMODS.xsl, as well as correcting the sequence of children elements in the new mods:location element.

## What's new?
Updated apply-templates in the new mods:location element at line 32, and added specific template match rules for the children elements.

## How should this be tested?
Using oXygen, apply the new utkMODStoMODS to the truncated example in Sample_Data/UTK/. Review the output.

## Interested parties
@markpbaggett 