### PR TITLE
Issue 19 recordContentSource

### DIFF
--- a/Sample_Data/UTK/short.volvoices.oai.mods.xml
+++ b/Sample_Data/UTK/short.volvoices.oai.mods.xml
@@ -86,8 +86,9 @@
           information, contact Special Collections at special@utk.edu.</accessCondition>
         <recordInfo>
           <recordIdentifier>record_0092_000050_000261_0001</recordIdentifier>
-          <recordContentSource>University of Tennessee, Knoxville. Special
-            Collections</recordContentSource>
+          <!--<recordContentSource>University of Tennessee, Knoxville. Special-->
+            <!--Collections</recordContentSource>-->
+          <recordContentSource></recordContentSource>
           <languageOfCataloging>
             <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
           </languageOfCataloging>

--- a/Sample_Data/UTK/short.volvoices.oai.mods.xml
+++ b/Sample_Data/UTK/short.volvoices.oai.mods.xml
@@ -86,9 +86,9 @@
           information, contact Special Collections at special@utk.edu.</accessCondition>
         <recordInfo>
           <recordIdentifier>record_0092_000050_000261_0001</recordIdentifier>
-          <!--<recordContentSource>University of Tennessee, Knoxville. Special-->
-            <!--Collections</recordContentSource>-->
-          <recordContentSource></recordContentSource>
+          <recordContentSource>University of Tennessee, Knoxville. Special
+            Collections</recordContentSource>
+          <!--<recordContentSource></recordContentSource>-->
           <languageOfCataloging>
             <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
           </languageOfCataloging>

--- a/XSLT/utkMODStoMODS.xsl
+++ b/XSLT/utkMODStoMODS.xsl
@@ -6,7 +6,7 @@
     <!-- parsed out top-level elements for ease of tweaking as feedback comes in. 
                 as source feed is worked on, this can be simplified -->
     
-    <xsl:template match="text()|@*"/>   
+    <xsl:template match="text()|@*"/>
     <xsl:template match="//mods:mods">
         <mods version="3.5" xmlns="http://www.loc.gov/mods/v3"
             xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -239,37 +239,42 @@
 
     <xsl:template match="mods:recordIdentifier">
         <xsl:copy copy-namespaces="no">
-            <xsl:apply-templates select="@*|node()"/>
+            <xsl:copy-of select="@*|node()" copy-namespaces="no"/>
         </xsl:copy>
     </xsl:template>
-    <xsl:template match="mods:recordContentSource">
+    <xsl:template match="mods:recordContentSource[not(. = '')]">
         <xsl:copy copy-namespaces="no">
-            <xsl:apply-templates select="@*|node()"/>
+            <xsl:copy-of select="@*|node()" copy-namespaces="no"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="mods:recordContentSource[(. = '')]">
+        <xsl:copy copy-namespaces="no">
+            <xsl:value-of select="'University of Tennessee'"/>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="mods:languageOfCataloging">
         <xsl:copy copy-namespaces="no">
-            <xsl:apply-templates select="@*|node()"/>
+            <xsl:copy-of select="@*|node()" copy-namespaces="no"/>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="mods:languageTerm">
         <xsl:copy copy-namespaces="no">
-            <xsl:apply-templates select="@*|node()"/>
+            <xsl:copy-of select="@*|node()" copy-namespaces="no"/>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="mods:recordOrigin">
         <xsl:copy copy-namespaces="no">
-            <xsl:apply-templates select="@*|node()"/>
+            <xsl:copy-of select="@*|node()" copy-namespaces="no"/>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="mods:recordCreationDate">
         <xsl:copy copy-namespaces="no">
-            <xsl:apply-templates select="@*|node()"/>
+            <xsl:copy-of select="@*|node()" copy-namespaces="no"/>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="mods:recordChangeDate">
         <xsl:copy copy-namespaces="no">
-            <xsl:apply-templates select="@*|node()"/>
+            <xsl:copy-of select="@*|node()" copy-namespaces="no"/>
         </xsl:copy>
     </xsl:template>
 

--- a/XSLT/utkMODStoMODS.xsl
+++ b/XSLT/utkMODStoMODS.xsl
@@ -225,6 +225,53 @@
     </xsl:template>
     
     <xsl:template match="mods:recordInfo">
-        <xsl:copy copy-namespaces="no"><xsl:copy-of select="node()|@*" copy-namespaces="no"></xsl:copy-of></xsl:copy>
+        <!--<xsl:copy copy-namespaces="no"><xsl:copy-of select="node()|@*" copy-namespaces="no"></xsl:copy-of></xsl:copy>-->
+        <xsl:copy copy-namespaces="no">
+            <xsl:apply-templates select="@*|node()"/>
+            <!--<xsl:copy-of select="@*|node()" copy-namespaces="no"/>-->
+            <!--<xsl:if test="mods:recordContentSource = ''">-->
+                <!--<recordContentSource>-->
+                    <!--<xsl:value-of select="'University of Tennessee'"/>-->
+                <!--</recordContentSource>-->
+            <!--</xsl:if>-->
+        </xsl:copy>
     </xsl:template>
+
+    <xsl:template match="mods:recordIdentifier">
+        <xsl:copy copy-namespaces="no">
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="mods:recordContentSource">
+        <xsl:copy copy-namespaces="no">
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="mods:languageOfCataloging">
+        <xsl:copy copy-namespaces="no">
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="mods:languageTerm">
+        <xsl:copy copy-namespaces="no">
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="mods:recordOrigin">
+        <xsl:copy copy-namespaces="no">
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="mods:recordCreationDate">
+        <xsl:copy copy-namespaces="no">
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="mods:recordChangeDate">
+        <xsl:copy copy-namespaces="no">
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+
 </xsl:stylesheet>


### PR DESCRIPTION
**GitHub Issue: [Issue 19 - recordContentSource](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/19)

## What does this Pull Request do?
Introduces granularity in how we're handling the UTK recordInfo element and its children. Specifically addresses the possibility of empty recordContentSource elements.

## What's new?
This PR adds child-level templates to the recordInfo rule, specifically to address potentially empty recordContentSource elements. XPath predicates are used to test for a child text() node in recordContentSource -- if there is one, there is a normal copy-of applied.

## How should this be tested?
Acquire my branch, and run the utkMODStoMODS.xsl against the Sample_Data/UTK/short.volvoices.oai.mods.xml. 

There is a commented out empty recordContentSource that can be used to verify proper behavior from the predicate tests.
## Interested parties

@markpbaggett 