### PR TITLE
address DPLA-47

### DIFF
--- a/Sample_Data/Country/records/musicaudio_2073.xml
+++ b/Sample_Data/Country/records/musicaudio_2073.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <oai_qdc:qualifieddc xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title>Red Foley - 'Wait For The Light To Shine' with introduction</dc:title>
+    <dc:description>Red Foley performs 'Wait For The Light To Shine' with an unidentified backing band.</dc:description>
+    <dc:creator>Red Foley</dc:creator>
+    <dcterms:tableOfContents>Red Foley talks -- Wait For The Light To Shine (Red Foley)</dcterms:tableOfContents>
+    <dc:format>10 inch metal-based acetate disc</dc:format>
+    <dc:format>78 rpm</dc:format>
+    <dc:identifier>TR000648_1</dc:identifier>
+    <dcterms:isPartOf>TR000648</dcterms:isPartOf>
+    <dcterms:created>2006-10-27</dcterms:created>
+    <dc:subject>Foley, Red, 1910-1968</dc:subject>
+    <dc:source>Country Music Foundation</dc:source>
+    <dcterms:accessRights>This audio file is the property of the Country Music Hall of Fame® and Museum and may be protected by U.S. and international copyright laws. The file may not be downloaded, reproduced, or distributed without permission. End users must obtain all required permissions or consents from the owners of such rights. To inquire about use permissions and obtain a high-quality version of this, contact audio@countrymusichalloffame.org. Please cite audio file information in email.</dcterms:accessRights>
+    <dcterms:rightsHolder>The Country Music Hall of Fame® and Museum is the exclusive owner of this content, including, without limitation, all copyrights. End users must obtain any other required permissions or consents, e.g., rights of privacy and rights of publicity, from the owners of such rights.</dcterms:rightsHolder>
+    <dc:identifier>http://digi.countrymusichalloffame.org/cdm/ref/collection/musicaudio/id/2073</dc:identifier>
+  </oai_qdc:qualifieddc>

--- a/Sample_Data/Country/records/musicaudio_2074.xml
+++ b/Sample_Data/Country/records/musicaudio_2074.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <oai_qdc:qualifieddc xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title>Red Foley - 'This World Is Not My Home' with introduction</dc:title>
+    <dc:description>Red Foley performs 'This World Is Not My Home' with an unidentified backing band.</dc:description>
+    <dc:creator>Red Foley</dc:creator>
+    <dcterms:tableOfContents>Red Foley talks -- This World Is Not My Home (Red Foley)</dcterms:tableOfContents>
+    <dc:format>10 inch metal-based acetate disc</dc:format>
+    <dc:format>78 rpm</dc:format>
+    <dc:identifier>TR000648_2</dc:identifier>
+    <dcterms:isPartOf>TR000648</dcterms:isPartOf>
+    <dcterms:created>2006-10-27</dcterms:created>
+    <dc:subject>Foley, Red, 1910-1968</dc:subject>
+    <dc:source>Country Music Foundation</dc:source>
+    <dcterms:accessRights>This audio file is the property of the Country Music Hall of Fame® and Museum and may be protected by U.S. and international copyright laws. The file may not be downloaded, reproduced, or distributed without permission. End users must obtain all required permissions or consents from the owners of such rights. To inquire about use permissions and obtain a high-quality version of this, contact audio@countrymusichalloffame.org. Please cite audio file information in email.</dcterms:accessRights>
+    <dcterms:rightsHolder>The Country Music Hall of Fame® and Museum is the exclusive owner of this content, including, without limitation, all copyrights. End users must obtain any other required permissions or consents, e.g., rights of privacy and rights of publicity, from the owners of such rights.</dcterms:rightsHolder>
+    <dc:identifier>http://digi.countrymusichalloffame.org/cdm/ref/collection/musicaudio/id/2074</dc:identifier>
+  </oai_qdc:qualifieddc>

--- a/Sample_Data/Country/records/musicaudio_4577.xml
+++ b/Sample_Data/Country/records/musicaudio_4577.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <oai_qdc:qualifieddc xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title>Take It To The Lord In Prayer performance</dc:title>
+    <dc:description>Unidentified radio excerpts, as well as a performance of Take It To The Lord In Prayer.</dc:description>
+    <dcterms:tableOfContents>[Unidentified audio] -- [Unidentified audio] -- Take It To The Lord In Prayer ([Unidentified])</dcterms:tableOfContents>
+    <dc:format>10 inch metal-based acetate disc</dc:format>
+    <dc:format>33 1/3 rpm</dc:format>
+    <dc:identifier>TR002608_2</dc:identifier>
+    <dcterms:isPartOf>TR002608</dcterms:isPartOf>
+    <dcterms:created>2016-10-25</dcterms:created>
+    <dc:source>Country Music Foundation</dc:source>
+    <dcterms:accessRights>This audio file is the property of the Country Music Hall of Fame® and Museum and may be protected by U.S. and international copyright laws. The file may not be downloaded, reproduced, or distributed without permission. End users must obtain all required permissions or consents from the owners of such rights. To inquire about use permissions and obtain a high-quality version of this, contact audio@countrymusichalloffame.org. Please cite audio file information in email.</dcterms:accessRights>
+    <dcterms:rightsHolder>The Country Music Hall of Fame® and Museum is the exclusive owner of this content, including, without limitation, all copyrights. End users must obtain any other required permissions or consents, e.g., rights of privacy and rights of publicity, from the owners of such rights.</dcterms:rightsHolder>
+    <dc:identifier>http://digi.countrymusichalloffame.org/cdm/ref/collection/musicaudio/id/4577</dc:identifier>
+  </oai_qdc:qualifieddc>

--- a/Sample_Data/Country/records/musicaudio_5149.xml
+++ b/Sample_Data/Country/records/musicaudio_5149.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <oai_qdc:qualifieddc xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title>Grand Ole Opry - Prince Albert - 1947-05-24 - Minnie Pearl performance - WSM</dc:title>
+    <dc:description>Excerpts from a Prince Albert tobacco sponsored Grand Ole Opry segment from May 24, 1947. Featuring Minnie Pearl on radio station WSM (Nashville, Tenn.)</dc:description>
+    <dc:date>1947-05-24</dc:date>
+    <dc:creator>Minnie Pearl</dc:creator>
+    <dcterms:tableOfContents>Opening theme (incomplete) -- Minnie Pearl talks -- Comedy routine (Minnie Pearl) -- Closing theme (incomplete)</dcterms:tableOfContents>
+    <dc:format>10 inch metal-based acetate disc</dc:format>
+    <dc:format>78 rpm</dc:format>
+    <dc:identifier>TR002943_2</dc:identifier>
+    <dcterms:isPartOf>TR002943</dcterms:isPartOf>
+    <dcterms:created>2017-05-02</dcterms:created>
+    <dc:subject>WSM (Radio station : Nashville, Tenn.); Grand ole opry (Radio program); Minnie Pearl; Cannon, Sarah Ophelia, 1912-1996;</dc:subject>
+    <dc:source>Country Music Foundation</dc:source>
+    <dcterms:accessRights>This audio file is the property of the Country Music Hall of Fame® and Museum and may be protected by U.S. and international copyright laws. The file may not be downloaded, reproduced, or distributed without permission. End users must obtain all required permissions or consents from the owners of such rights. To inquire about use permissions and obtain a high-quality version of this, contact audio@countrymusichalloffame.org. Please cite audio file information in email.</dcterms:accessRights>
+    <dcterms:rightsHolder>The Country Music Hall of Fame® and Museum is the exclusive owner of this content, including, without limitation, all copyrights. End users must obtain any other required permissions or consents, e.g., rights of privacy and rights of publicity, from the owners of such rights.</dcterms:rightsHolder>
+    <dc:identifier>http://digi.countrymusichalloffame.org/cdm/ref/collection/musicaudio/id/5149</dc:identifier>
+  </oai_qdc:qualifieddc>

--- a/XSLT/countryqdctomods.xsl
+++ b/XSLT/countryqdctomods.xsl
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.og/2001/XMLSchema"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+                xmlns:dcterms="http://purl.org/dc/terms/"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+                xmlns:functx="http://www.functx.com"
+                xmlns="http://www.loc.gov/mods/v3"
+                exclude-result-prefixes="#all"
+                version="2.0">
+  <!-- output settings -->
+  <xsl:output encoding="UTF-8" method="xml" omit-xml-declaration="yes" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+
+  <!-- includes and imports -->
+    
+  <!--
+    Collection/Set = Country Music Hall of Fame and Museum (CHMF)
+  -->
+  
+  <!-- identity transform -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+  
+  <!-- normalize all the text! -->
+  <xsl:template match="text()">
+    <xsl:value-of select="normalize-space(.)"/>
+  </xsl:template>
+
+  <!-- match oai_qdc:qualifieddc -->
+  <xsl:template match="oai_qdc:qualifieddc">
+    <!-- match the document root and return a MODS record -->
+    <mods xmlns="http://www.loc.gov/mods/v3" version="3.5" 
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+      <!-- title -->
+      <xsl:apply-templates select="dc:title"/>
+      <!-- accessRights -->
+      <xsl:apply-templates select="dcterms:accessRights"/>
+      <!-- description -->
+      <xsl:apply-templates select="dc:description"/>
+      <!-- subject(s) -->
+      <xsl:apply-templates select="dc:subject"/>
+      <!-- creator(s) -->
+      <xsl:apply-templates select="dc:creator"/>
+      <!-- identifier(s) that are not URLs -->
+      <xsl:apply-templates select="dc:identifier[not(starts-with(., 'http://'))]"/>
+      <!-- location: physicalLocation and URLs -->
+      <location>
+        <!-- identifier beginning with 'http://' -->
+        <xsl:apply-templates select="dc:identifier[starts-with(., 'http://')]"/>
+      </location>
+      <!-- physicalDescription -->
+      <physicalDescription>
+        <!-- format(s) -->
+        <xsl:apply-templates select="dc:format"/>
+      </physicalDescription>
+      <!-- recordInfo -->
+      <xsl:call-template name="record-info"/>
+    </mods>
+  </xsl:template>
+  
+  <!-- title -->
+  <xsl:template match="dc:title">
+    <titleInfo>
+      <title><xsl:apply-templates/></title>
+    </titleInfo>
+  </xsl:template>
+  
+  <!-- accessRights -->
+  <xsl:template match="dcterms:accessRights">
+    <accessCondition><xsl:apply-templates/></accessCondition>
+  </xsl:template>
+  
+  <!-- description -->
+  <xsl:template match="dc:description">
+   <abstract><xsl:apply-templates/></abstract> 
+  </xsl:template>
+  
+  <!-- subject(s) -->
+  <!-- for subjects with a trailing ';' -->
+  <xsl:template match="dc:subject[ends-with(., ';')]">
+    <!--<xsl:variable name="subj-tokens" select="tokenize(functx:substring-before-last(., ';'), ';')"/>-->
+    <xsl:variable name="subj-tokens" select="tokenize(.,';')"/>
+    <xsl:for-each select="$subj-tokens">
+      <subject>
+        <topic><xsl:value-of select="normalize-space(.)"/></topic>
+      </subject>
+    </xsl:for-each>
+  </xsl:template>
+  
+  <!-- a template to match subjects that do *not* end with a trailing ';' -->
+  <xsl:template match="dc:subject[not(ends-with(., ';'))]">
+    <subject>
+      <topic><xsl:apply-templates/></topic>
+    </subject>
+  </xsl:template>
+
+  <!-- creator(s) -->
+  <xsl:template match="dc:creator">
+    <xsl:variable name="creator-tokens" select="tokenize(., ';')"/>
+    <xsl:for-each select="$creator-tokens">
+      <name>
+        <namePart><xsl:value-of select="normalize-space(.)"/></namePart>
+        <role>
+          <roleTerm type="text" valueURI="http://id.loc.gov/vocabular/relators/cre">Creator</roleTerm>
+        </role>
+      </name>
+    </xsl:for-each>
+  </xsl:template>
+  
+  <!-- identifier(s) -->
+  <!-- identifier - location processing -->
+  <xsl:template match="dc:identifier[starts-with(., 'http://')]">
+    <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
+    <url usage="primary" access="object in context"><xsl:apply-templates/></url>
+    <url usage="primary" access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
+  </xsl:template>
+  
+  <!-- a template to match identifiers that do *not* start with 'http://' -->
+  <xsl:template match="dc:identifier[not(starts-with(., 'http://'))]">
+    <identifier type="local"><xsl:apply-templates/></identifier>
+  </xsl:template>
+  
+  <!-- format(s) -->
+  <xsl:template match="dc:format">
+    <form><xsl:apply-templates/></form>
+  </xsl:template>
+  
+  <!-- record-info template -->
+  <xsl:template name="record-info">
+    <recordInfo>
+      <!-- not sure about the values for some of these elements; maybe we don't want them at all? -->
+      <recordContentSource>Country Music Hall of Fame and Museum</recordContentSource>
+      <recordChangeDate><xsl:value-of select="current-date()"/></recordChangeDate>
+      <languageOfCataloging>
+        <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+      </languageOfCataloging>
+      <recordOrigin>Record has been transformed into MODS v3.5 from a Qualified Dublin Core record by the Digital Library of Tennessee, a service hub of the Digital Public Library of America.</recordOrigin>
+    </recordInfo>
+  </xsl:template>
+  
+  <!-- functions -->
+  <!-- pulled from the functx stylesheet due to compliation errors with Saxon 8.7 -->
+  <xsl:function name="functx:substring-before-last">
+    <xsl:param name="arg"/> 
+    <xsl:param name="delim"/> 
+    
+    <xsl:sequence select=" 
+      if (matches($arg, functx:escape-for-regex($delim)))
+      then replace($arg,
+      concat('^(.*)', functx:escape-for-regex($delim),'.*'),
+      '$1')
+      else ''
+      "/>
+    
+  </xsl:function>
+  
+  <xsl:function name="functx:escape-for-regex">
+    <xsl:param name="arg"/> 
+    
+    <xsl:sequence select=" 
+      replace($arg,
+      '(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')
+      "/>
+    
+  </xsl:function>
+</xsl:stylesheet>
+

--- a/XSLT/countryqdctomods.xsl
+++ b/XSLT/countryqdctomods.xsl
@@ -120,7 +120,7 @@
   <xsl:template match="dc:identifier[starts-with(., 'http://')]">
     <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
     <url usage="primary" access="object in context"><xsl:apply-templates/></url>
-    <url usage="primary" access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
+    <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
   </xsl:template>
   
   <!-- a template to match identifiers that do *not* start with 'http://' -->


### PR DESCRIPTION


**JIRA Issue: [DPLA-47](https://jira.lib.utk.edu/browse/DPLA-47)

## What does this Pull Request do?
This PR adds a QDC-to-MODS XSL transform, as well as sample data files, for Country Music Hall of Fame.

## What's new?
The following files have been added to the repository:
```
|--Sample_Data
  |--Country
    |--countryqdc.xml
      |--records
        |--musicaudio_2073.xml
        |--musicaudio_2074.xml
        |--musicaudio_4577.xml
        |--musicaudio_5149.xml
|--XSLT
  |--countryqdctomods.xsl
```
The `countryqdctomods` stylesheet converts the files under Sample_Data/Country/records to valid MODS. 

## How should this be tested?
* Acquire my branch and open the new stylesheet in oXygen.
* Configure a transform scenario and be sure to use Saxon 8.7!
* Run the transformation scenario
  * There are **recoverable** errors reported by Saxon 8.7. These do **not** effect the output of the transform.
* After applying the transform, quality control the output using your methodology of choice.

## Additional Notes:


## Interested parties
@markpbaggett
