### PR TITLE
Address DPLA-74 DLTN-41

### DIFF
--- a/XSLT/coreDCtoMODS.xsl
+++ b/XSLT/coreDCtoMODS.xsl
@@ -15,8 +15,24 @@
         dc:title[1]
         dc:title[position()>1]
     -->
-    
-    <xsl:template match="dc:date"> 
+
+    <!-- variables and parameters-->
+    <xsl:param name="pRights">
+        <rs uri="http://rightsstatements.org/vocab/InC/1.0/" string="">in copyright</rs>
+        <rs uri="http://rightsstatements.org/vocab/InC-OW-EU/1.0/" string="">in copyright - eu orphan work</rs>
+        <rs uri="http://rightsstatements.org/vocab/InC-EDU/1.0/" string="">in copyright - educational use permitted</rs>
+        <rs uri="http://rightsstatements.org/vocab/InC-NC/1.0/" string="">in copyright - non-commercial use permitted</rs>
+        <rs uri="http://rightsstatements.org/vocab/InC-RUU/1.0/" string="">in copyright - rights-holder(s) unlocatable or unidentifiable</rs>
+        <rs uri="http://rightsstatements.org/vocab/NoC-CR/1.0/" string="">no copyright - contractual restrictions</rs>
+        <rs uri="http://rightsstatements.org/vocab/NoC-NC/1.0/" string="">no copyright - non-commercial use only</rs>
+        <rs uri="http://rightsstatements.org/vocab/NoC-OKLR/1.0/" string="">no copyright - other known legal restrictions</rs>
+        <rs uri="http://rightsstatements.org/vocab/NoC-US/1.0/" string="">no copyright - united states</rs>
+        <rs uri="http://rightsstatements.org/vocab/CNE/1.0/" string="">copyright not evaluated</rs>
+        <rs uri="http://rightsstatements.org/vocab/UND/1.0/" string="">copyright undetermined</rs>
+        <rs uri="http://rightsstatements.org/vocab/NKC/1.0/" string="">no known copyright</rs>
+    </xsl:param>
+
+    <xsl:template match="dc:date">
         <xsl:for-each select="tokenize(normalize-space(.), ';')">
             <xsl:if test="normalize-space(.)!='' and normalize-space(lower-case(.))!='n/a'">
                 <xsl:choose>

--- a/XSLT/coreDCtoMODS.xsl
+++ b/XSLT/coreDCtoMODS.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xmlns:dc="http://purl.org/dc/elements/1.1/" 
-    xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+    xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:xlink="http://www.w3.org/1999/xlink"
     version="2.0" xmlns="http://www.loc.gov/mods/v3">
     <xsl:output omit-xml-declaration="yes" method="xml" encoding="UTF-8" indent="yes"/>
     

--- a/XSLT/coreDCtoMODS.xsl
+++ b/XSLT/coreDCtoMODS.xsl
@@ -32,6 +32,9 @@
         <rs uri="http://rightsstatements.org/vocab/NKC/1.0/" string="No Known Copyright">no known copyright</rs>
     </xsl:param>
 
+    <xsl:variable name="vRightsString" select="normalize-space(string-join(//dc:rights, ' '))"/>
+    <xsl:variable name="vRightsCount" select="count(//dc:rights)"/>
+
     <xsl:template match="dc:date">
         <xsl:for-each select="tokenize(normalize-space(.), ';')">
             <xsl:if test="normalize-space(.)!='' and normalize-space(lower-case(.))!='n/a'">
@@ -530,30 +533,37 @@
         </xsl:for-each>
     </xsl:template>
     
-    <xsl:template match="dc:rights">
+    <xsl:template match="dc:rights[1]">
         <xsl:variable name="vText"
                       select="if (contains(normalize-space(.), 'http://'))
                               then (normalize-space(.))
                               else (lower-case(normalize-space(.)))"/>
         <xsl:choose>
-            <xsl:when test="$vText = $pRights/rs/@uri">
-                <accessCondition type="use and reproduction" xlink:href="{$vText}">
-                    <xsl:value-of select="$pRights/rs[@uri = $vText]/@string"/>
-                </accessCondition>
-            </xsl:when>
-            <xsl:when test="$vText = $pRights/rs">
-                <accessCondition type="use and reproduction" xlink:href="{$pRights/r[. = $vText]/@uri}">
-                    <xsl:value-of select="$pRights/rs[. = $vText]/@string"/>
-                </accessCondition>
-            </xsl:when>
-            <!-- keep public domain test but map to no copyright - united states -->
-            <xsl:when test="contains($vText, 'public domain')">
-                <accessCondition type="use and reproduction" xlink:href="http://rightsstatement.org/vocab/NoC-US/1.0/">No Copyright - United States</accessCondition>
+            <xsl:when test="$vRightsCount > 1">
+                <accessCondition type="local rights statement"><xsl:value-of select="$vRightsString"/></accessCondition>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:if test="$vText != ''">
-                    <accessCondition type="local rights statement"><xsl:value-of select="normalize-space(.)"/></accessCondition>
-                </xsl:if>
+                <xsl:choose>
+                    <xsl:when test="$vText = $pRights/rs/@uri">
+                        <accessCondition type="use and reproduction" xlink:href="{$vText}">
+                            <xsl:value-of select="$pRights/rs[@uri = $vText]/@string"/>
+                        </accessCondition>
+                    </xsl:when>
+                    <xsl:when test="$vText = $pRights/rs">
+                        <accessCondition type="use and reproduction" xlink:href="{$pRights/r[. = $vText]/@uri}">
+                            <xsl:value-of select="$pRights/rs[. = $vText]/@string"/>
+                        </accessCondition>
+                    </xsl:when>
+                    <!-- keep public domain test but map to no copyright - united states -->
+                    <xsl:when test="contains($vText, 'public domain')">
+                        <accessCondition type="use and reproduction" xlink:href="http://rightsstatement.org/vocab/NoC-US/1.0/">No Copyright - United States</accessCondition>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:if test="$vText != ''">
+                            <accessCondition type="local rights statement"><xsl:value-of select="normalize-space(.)"/></accessCondition>
+                        </xsl:if>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/coreDCtoMODS.xsl
+++ b/XSLT/coreDCtoMODS.xsl
@@ -531,14 +531,29 @@
     </xsl:template>
     
     <xsl:template match="dc:rights">
+        <xsl:variable name="vText"
+                      select="if (contains(normalize-space(.), 'http://'))
+                              then (normalize-space(.))
+                              else (lower-case(normalize-space(.)))"/>
         <xsl:choose>
-            <xsl:when test="contains(normalize-space(lower-case(.)),'public domain')">
-                <accessCondition>Public domain</accessCondition>
+            <xsl:when test="$vText = $pRights/rs/@uri">
+                <accessCondition type="use and reproduction" xlink:href="{$vText}">
+                    <xsl:value-of select="$pRights/rs[@uri = $vText]/@string"/>
+                </accessCondition>
+            </xsl:when>
+            <xsl:when test="$vText = $pRights/rs">
+                <accessCondition type="use and reproduction" xlink:href="{$pRights/r[. = $vText]/@uri}">
+                    <xsl:value-of select="$pRights/rs[. = $vText]/@string"/>
+                </accessCondition>
+            </xsl:when>
+            <!-- keep public domain test but map to no copyright - united states -->
+            <xsl:when test="contains($vText, 'public domain')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatement.org/vocab/NoC-US/1.0/">No Copyright - United States</accessCondition>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:if test="normalize-space(.)!=''">
-                    <accessCondition><xsl:value-of select="normalize-space(.)"/></accessCondition>
-                </xsl:if>     
+                <xsl:if test="$vText != ''">
+                    <accessCondition type="local rights statement"><xsl:value-of select="normalize-space(.)"/></accessCondition>
+                </xsl:if>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/coreDCtoMODS.xsl
+++ b/XSLT/coreDCtoMODS.xsl
@@ -18,18 +18,18 @@
 
     <!-- variables and parameters-->
     <xsl:param name="pRights">
-        <rs uri="http://rightsstatements.org/vocab/InC/1.0/" string="">in copyright</rs>
-        <rs uri="http://rightsstatements.org/vocab/InC-OW-EU/1.0/" string="">in copyright - eu orphan work</rs>
-        <rs uri="http://rightsstatements.org/vocab/InC-EDU/1.0/" string="">in copyright - educational use permitted</rs>
-        <rs uri="http://rightsstatements.org/vocab/InC-NC/1.0/" string="">in copyright - non-commercial use permitted</rs>
-        <rs uri="http://rightsstatements.org/vocab/InC-RUU/1.0/" string="">in copyright - rights-holder(s) unlocatable or unidentifiable</rs>
-        <rs uri="http://rightsstatements.org/vocab/NoC-CR/1.0/" string="">no copyright - contractual restrictions</rs>
-        <rs uri="http://rightsstatements.org/vocab/NoC-NC/1.0/" string="">no copyright - non-commercial use only</rs>
-        <rs uri="http://rightsstatements.org/vocab/NoC-OKLR/1.0/" string="">no copyright - other known legal restrictions</rs>
-        <rs uri="http://rightsstatements.org/vocab/NoC-US/1.0/" string="">no copyright - united states</rs>
-        <rs uri="http://rightsstatements.org/vocab/CNE/1.0/" string="">copyright not evaluated</rs>
-        <rs uri="http://rightsstatements.org/vocab/UND/1.0/" string="">copyright undetermined</rs>
-        <rs uri="http://rightsstatements.org/vocab/NKC/1.0/" string="">no known copyright</rs>
+        <rs uri="http://rightsstatements.org/vocab/InC/1.0/" string="In Copyright">in copyright</rs>
+        <rs uri="http://rightsstatements.org/vocab/InC-OW-EU/1.0/" string="In Copyright - EU Orphan Work">in copyright - eu orphan work</rs>
+        <rs uri="http://rightsstatements.org/vocab/InC-EDU/1.0/" string="In Copyright - Educational Use Permitted">in copyright - educational use permitted</rs>
+        <rs uri="http://rightsstatements.org/vocab/InC-NC/1.0/" string="In Copyright - Non-Commercial Use Permitted">in copyright - non-commercial use permitted</rs>
+        <rs uri="http://rightsstatements.org/vocab/InC-RUU/1.0/" string="In Copyright - Rights-holder(s) Unlocatable or Unidentifiable">in copyright - rights-holder(s) unlocatable or unidentifiable</rs>
+        <rs uri="http://rightsstatements.org/vocab/NoC-CR/1.0/" string="No Copyright - Contractual Restrictions">no copyright - contractual restrictions</rs>
+        <rs uri="http://rightsstatements.org/vocab/NoC-NC/1.0/" string="No Copyright - Non-Commercial Use Only">no copyright - non-commercial use only</rs>
+        <rs uri="http://rightsstatements.org/vocab/NoC-OKLR/1.0/" string="No Copyright - Other Known Legal Restrictions">no copyright - other known legal restrictions</rs>
+        <rs uri="http://rightsstatements.org/vocab/NoC-US/1.0/" string="No Copyright - United States">no copyright - united states</rs>
+        <rs uri="http://rightsstatements.org/vocab/CNE/1.0/" string="Copyright Not Evaluated">copyright not evaluated</rs>
+        <rs uri="http://rightsstatements.org/vocab/UND/1.0/" string="Copyright Undetermined">copyright undetermined</rs>
+        <rs uri="http://rightsstatements.org/vocab/NKC/1.0/" string="No Known Copyright">no known copyright</rs>
     </xsl:param>
 
     <xsl:template match="dc:date">

--- a/XSLT/countryqdctomods.xsl
+++ b/XSLT/countryqdctomods.xsl
@@ -75,7 +75,7 @@
   
   <!-- accessRights -->
   <xsl:template match="dcterms:accessRights">
-    <accessCondition><xsl:apply-templates/></accessCondition>
+    <accessCondition type='local rights statement'><xsl:apply-templates/></accessCondition>
   </xsl:template>
   
   <!-- description -->

--- a/XSLT/crossroadsDCtoMODS.xsl
+++ b/XSLT/crossroadsDCtoMODS.xsl
@@ -390,7 +390,7 @@
                 <xsl:apply-templates select="dc:rights"/>
             </xsl:when>
             <xsl:otherwise>
-                <accessCondition>Crossroads to Freedom Digital Archive is licensed under the Creative Commons Attribution License. Use of the site's content is subject to the conditions and terms of use on our Legal Notices page.</accessCondition>
+                <accessCondition type='local rights statement'>Crossroads to Freedom Digital Archive is licensed under the Creative Commons Attribution License. Use of the site's content is subject to the conditions and terms of use on our Legal Notices page.</accessCondition>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/knoxp265301coll005DCtoMODS.xsl
+++ b/XSLT/knoxp265301coll005DCtoMODS.xsl
@@ -63,7 +63,7 @@
     <!-- Typo Repairs, Static Additions -->
     
     <xsl:template name="dc:rightsTypoRepair">
-        <accessCondition>To use photographs or to order reproductions, contact DigitalCollections@knoxlib.org or phone 865 215-8808. Please refer to Image Number and provide a brief description of the photograph.</accessCondition>
+        <accessCondition type='local rights statement'>To use photographs or to order reproductions, contact DigitalCollections@knoxlib.org or phone 865 215-8808. Please refer to Image Number and provide a brief description of the photograph.</accessCondition>
     </xsl:template>
     
     <xsl:template name="photocollLanguage">

--- a/XSLT/knoxp265301coll7DCtoMODS.xsl
+++ b/XSLT/knoxp265301coll7DCtoMODS.xsl
@@ -63,7 +63,7 @@
         
 <!-- Typo Repairs, Static Additions -->
     <xsl:template name="dc:rightsTypoRepair">
-        <accessCondition>To use photographs or to order reproductions, contact DigitalCollections@knoxlib.org or phone 865 215-8808. Please refer to Image Number and provide a brief description of the photograph.</accessCondition>
+        <accessCondition type='local rights statement'>To use photographs or to order reproductions, contact DigitalCollections@knoxlib.org or phone 865 215-8808. Please refer to Image Number and provide a brief description of the photograph.</accessCondition>
     </xsl:template>
     
     <xsl:template name="photocollLanguage">

--- a/XSLT/knoxp265301coll8DCtoMODS.xsl
+++ b/XSLT/knoxp265301coll8DCtoMODS.xsl
@@ -64,7 +64,7 @@
     <!-- Typo Repairs, Static Additions -->
     
     <xsl:template name="dc:rightsTypoRepair">
-        <accessCondition>To use material or to order reproductions, contact DigitalCollections@knoxlib.org or phone 865 215-8808. Please provide a brief description of the material.</accessCondition>
+        <accessCondition type='local rights statement'>To use material or to order reproductions, contact DigitalCollections@knoxlib.org or phone 865 215-8808. Please provide a brief description of the material.</accessCondition>
     </xsl:template>
     
     

--- a/XSLT/memphisp13039coll5DCtoMODS.xsl
+++ b/XSLT/memphisp13039coll5DCtoMODS.xsl
@@ -125,10 +125,10 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition><xsl:value-of select="dc:rights"/></accessCondition>
+                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
             </xsl:when>
             <xsl:otherwise>
-                <accessCondition>Digital Image, Memphis Public Library &amp; Information Center. All rights reserved. While the Memphis Public Library &amp; Information Center may house an item, it does not necessarily hold the copyright on the item, nor may it be able to determine if the item is still protected under current copyright law. Users are solely responsible for determining the existence of such instances and for obtaining any other permissions and paying associated fees that may be necessary for the intended use. Any image from the library's collection published in any form must cite as the source: Memphis and Shelby County Room, Memphis Public Library &amp; Information Center.  For all requests, please contact the History Department at 901.415.2742 or hisref@memphistn.gov.</accessCondition>
+                <accessCondition type='local rights statement'>Digital Image, Memphis Public Library &amp; Information Center. All rights reserved. While the Memphis Public Library &amp; Information Center may house an item, it does not necessarily hold the copyright on the item, nor may it be able to determine if the item is still protected under current copyright law. Users are solely responsible for determining the existence of such instances and for obtaining any other permissions and paying associated fees that may be necessary for the intended use. Any image from the library's collection published in any form must cite as the source: Memphis and Shelby County Room, Memphis Public Library &amp; Information Center.  For all requests, please contact the History Department at 901.415.2742 or hisref@memphistn.gov.</accessCondition>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/memphisp13039coll5DCtoMODS.xsl
+++ b/XSLT/memphisp13039coll5DCtoMODS.xsl
@@ -125,7 +125,7 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
+                <xsl:apply-templates select="dc:rights"/>
             </xsl:when>
             <xsl:otherwise>
                 <accessCondition type='local rights statement'>Digital Image, Memphis Public Library &amp; Information Center. All rights reserved. While the Memphis Public Library &amp; Information Center may house an item, it does not necessarily hold the copyright on the item, nor may it be able to determine if the item is still protected under current copyright law. Users are solely responsible for determining the existence of such instances and for obtaining any other permissions and paying associated fees that may be necessary for the intended use. Any image from the library's collection published in any form must cite as the source: Memphis and Shelby County Room, Memphis Public Library &amp; Information Center.  For all requests, please contact the History Department at 901.415.2742 or hisref@memphistn.gov.</accessCondition>

--- a/XSLT/mtsuDCtoMODS.xsl
+++ b/XSLT/mtsuDCtoMODS.xsl
@@ -604,7 +604,7 @@
                         </relatedItem>
                     </xsl:when>
                     <xsl:when test="contains(.,'All rights reserved') or contains(.,'Courtesy of')"> 
-                        <accessCondition><xsl:value-of select="normalize-space(.)"/></accessCondition>
+                        <accessCondition type='local rights statement'><xsl:value-of select="normalize-space(.)"/></accessCondition>
                     </xsl:when>
                     <xsl:when test="contains(.,', photographer')"> 
                         <name>

--- a/XSLT/mtsucannonDCtoMODS.xsl
+++ b/XSLT/mtsucannonDCtoMODS.xsl
@@ -132,10 +132,10 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition><xsl:value-of select="dc:rights"/></accessCondition>
+                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
             </xsl:when>
             <xsl:otherwise>
-                <accessCondition>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
+                <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/mtsucannonDCtoMODS.xsl
+++ b/XSLT/mtsucannonDCtoMODS.xsl
@@ -132,7 +132,7 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
+                <xsl:apply-templates select="dc:rights"/>
             </xsl:when>
             <xsl:otherwise>
                 <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>

--- a/XSLT/mtsumtsu1DCtoMODS.xsl
+++ b/XSLT/mtsumtsu1DCtoMODS.xsl
@@ -127,7 +127,7 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
+                <xsl:apply-templates select="dc:rights"/>
             </xsl:when>
             <xsl:otherwise>
                 <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>

--- a/XSLT/mtsumtsu1DCtoMODS.xsl
+++ b/XSLT/mtsumtsu1DCtoMODS.xsl
@@ -127,10 +127,10 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition><xsl:value-of select="dc:rights"/></accessCondition>
+                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
             </xsl:when>
             <xsl:otherwise>
-                <accessCondition>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
+                <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/mtsup15838coll4DCtoMODS.xsl
+++ b/XSLT/mtsup15838coll4DCtoMODS.xsl
@@ -147,7 +147,7 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
+                <xsl:apply-templates select="dc:rights"/>
             </xsl:when>
             <xsl:otherwise>
                 <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>

--- a/XSLT/mtsup15838coll4DCtoMODS.xsl
+++ b/XSLT/mtsup15838coll4DCtoMODS.xsl
@@ -147,10 +147,10 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition><xsl:value-of select="dc:rights"/></accessCondition>
+                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
             </xsl:when>
             <xsl:otherwise>
-                <accessCondition>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
+                <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/mtsup15838coll7DCtoMODS.xsl
+++ b/XSLT/mtsup15838coll7DCtoMODS.xsl
@@ -156,7 +156,7 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
+                <xsl:apply-templates select="dc:rights"/>
             </xsl:when>
             <xsl:otherwise>
                 <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>

--- a/XSLT/mtsup15838coll7DCtoMODS.xsl
+++ b/XSLT/mtsup15838coll7DCtoMODS.xsl
@@ -156,10 +156,10 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition><xsl:value-of select="dc:rights"/></accessCondition>
+                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
             </xsl:when>
             <xsl:otherwise>
-                <accessCondition>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
+                <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/mtsuschoolsDCtoMODS.xsl
+++ b/XSLT/mtsuschoolsDCtoMODS.xsl
@@ -66,7 +66,7 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
+                <xsl:apply-templates select="dc:rights"/>
             </xsl:when>
             <xsl:otherwise>
                 <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>

--- a/XSLT/mtsuschoolsDCtoMODS.xsl
+++ b/XSLT/mtsuschoolsDCtoMODS.xsl
@@ -66,10 +66,10 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition><xsl:value-of select="dc:rights"/></accessCondition>
+                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
             </xsl:when>
             <xsl:otherwise>
-                <accessCondition>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
+                <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/mtsushadesDCtoMODS.xsl
+++ b/XSLT/mtsushadesDCtoMODS.xsl
@@ -146,10 +146,10 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition><xsl:value-of select="dc:rights"/></accessCondition>
+                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
             </xsl:when>
             <xsl:otherwise>
-                <accessCondition>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
+                <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/mtsushadesDCtoMODS.xsl
+++ b/XSLT/mtsushadesDCtoMODS.xsl
@@ -146,7 +146,7 @@
     <xsl:template name="rightsRepair"> <!-- some elements missing rights statement, which is required. Existing mapped, those without, given generic.-->
         <xsl:choose>
             <xsl:when test="dc:rights">
-                <accessCondition type='local rights statement'><xsl:value-of select="dc:rights"/></accessCondition>
+                <xsl:apply-templates select="dc:rights"/>
             </xsl:when>
             <xsl:otherwise>
                 <accessCondition type='local rights statement'>Check with the MTSU Digital Collections team to assess copyright. Have the object identifier and title available with your request. http://cdm15838.contentdm.oclc.org/cdm/</accessCondition>

--- a/XSLT/nashvilleDCtoMODS.xsl
+++ b/XSLT/nashvilleDCtoMODS.xsl
@@ -558,7 +558,7 @@
         <xsl:for-each select="tokenize(normalize-space(.), ';')">
             <xsl:if test="normalize-space(.)!=''">
                 <xsl:if test="starts-with(normalize-space(.), 'U.S. and international copyright laws')">
-                    <accessCondition><xsl:value-of select="normalize-space(.)"/></accessCondition>
+                    <accessCondition type='local rights statement'><xsl:value-of select="normalize-space(.)"/></accessCondition>
                 </xsl:if>
             </xsl:if>
         </xsl:for-each>

--- a/XSLT/nashvillenrDCtoMODS.xsl
+++ b/XSLT/nashvillenrDCtoMODS.xsl
@@ -69,10 +69,10 @@
     <xsl:template name="rightsRepair">
         <xsl:choose>
             <xsl:when test="dc:rights!='' and not(starts-with(dc:rights, 'unde'))">
-                <accessCondition><xsl:value-of select="normalize-space(dc:rights)"/></accessCondition>
+                <accessCondition type='local rights statement'><xsl:value-of select="normalize-space(dc:rights)"/></accessCondition>
             </xsl:when>
             <xsl:otherwise>
-                <accessCondition>For rights information of this object, please contact: Metro Nashville Archives, 615 Church Street, Nashville, Tennessee, 37219. Telephone (615) 862-5880.</accessCondition>
+                <accessCondition type='local rights statement'>For rights information of this object, please contact: Metro Nashville Archives, 615 Church Street, Nashville, Tennessee, 37219. Telephone (615) 862-5880.</accessCondition>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/nashvillenrDCtoMODS.xsl
+++ b/XSLT/nashvillenrDCtoMODS.xsl
@@ -69,7 +69,8 @@
     <xsl:template name="rightsRepair">
         <xsl:choose>
             <xsl:when test="dc:rights!='' and not(starts-with(dc:rights, 'unde'))">
-                <accessCondition type='local rights statement'><xsl:value-of select="normalize-space(dc:rights)"/></accessCondition>
+                <!--<accessCondition type='local rights statement'><xsl:value-of select="normalize-space(dc:rights)"/></accessCondition>-->
+                <xsl:apply-templates select="dc:rights[not(starts-with(., 'unde'))]"/>
             </xsl:when>
             <xsl:otherwise>
                 <accessCondition type='local rights statement'>For rights information of this object, please contact: Metro Nashville Archives, 615 Church Street, Nashville, Tennessee, 37219. Telephone (615) 862-5880.</accessCondition>

--- a/XSLT/tslaDCtoMODS.xsl
+++ b/XSLT/tslaDCtoMODS.xsl
@@ -57,7 +57,7 @@
                 <xsl:apply-templates select="dc:rights"/>
             </xsl:when>
             <xsl:otherwise>
-                <accessCondition>While TSLA houses an item, it does not necessarily hold the copyright on the item, nor may it be able to determine if the item is still protected under current copyright law. Users are solely responsible for determining the existence of such instances and for obtaining any other permissions and paying associated fees that may be necessary for the intended use.</accessCondition>
+                <accessCondition type='local rights statement'>While TSLA houses an item, it does not necessarily hold the copyright on the item, nor may it be able to determine if the item is still protected under current copyright law. Users are solely responsible for determining the existence of such instances and for obtaining any other permissions and paying associated fees that may be necessary for the intended use.</accessCondition>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/XSLT/utcDCtoMODS.xsl
+++ b/XSLT/utcDCtoMODS.xsl
@@ -409,7 +409,7 @@
                     <xsl:apply-templates select="."/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <accessCondition>Under copyright.</accessCondition>
+                    <accessCondition type='local rights statement'>Under copyright.</accessCondition>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:for-each>


### PR DESCRIPTION
**GitHub Issue: [DPLA-74](https://jira.lib.utk.edu/projects/DPLA/issues/DPLA-74) | [DLTN-41](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/41)

## What does this Pull Request do?
This PR adds two pieces of functionality:
1) it adds rightsstatements.org parsing to output  `mods:accessCondition` and appropriate attributes, and
2) it adds templating that attempts to force multiple `dc:rights` elements to one `mods:accessCondition` element.

## What's new?
1) Parameters and variables in coreDCtoMODS that allow for rightsstatements.org parsing and `dc:rights` processing accordingly.
2) Updated `dc:rights` template for said processing.
3) Updated `mods:accessCondition` serialization to reflect rightsstatements.org URIs and statements.
4) Updated `mods:accessCondition` serialization to differentiate between local rights statements and rightsstatements.org URIs/statements.

## How should this be tested?

A description of what steps someone could take to:
* Verify in a Repox instance
* Test with Saxopn 8.7

## Interested parties
@markpbaggett 