### PR TITLE
fix weird wrapping in functions

### DIFF
--- a/XSLT/countryqdctomods.xsl
+++ b/XSLT/countryqdctomods.xsl
@@ -152,24 +152,16 @@
     <xsl:param name="arg"/> 
     <xsl:param name="delim"/> 
     
-    <xsl:sequence select=" 
-      if (matches($arg, functx:escape-for-regex($delim)))
-      then replace($arg,
-      concat('^(.*)', functx:escape-for-regex($delim),'.*'),
-      '$1')
-      else ''
-      "/>
+    <xsl:sequence select="if (matches($arg, functx:escape-for-regex($delim)))
+                          then replace($arg, concat('^(.*)', functx:escape-for-regex($delim),'.*'), '$1')
+                          else ''"/>
     
   </xsl:function>
   
   <xsl:function name="functx:escape-for-regex">
     <xsl:param name="arg"/> 
     
-    <xsl:sequence select=" 
-      replace($arg,
-      '(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')
-      "/>
-    
+    <xsl:sequence select="replace($arg, '(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
   </xsl:function>
 </xsl:stylesheet>
 


### PR DESCRIPTION
**GitHub Issue: n/a

## What does this Pull Request do?
This PR attempts to clean up some weird formatting in two function definitions.

## What's new?
The whitespace in the function definitions has been cleaned up, hopefully improving the legibility of the code. Functionally, there's no difference.

## Interested parties
@markpbaggett