### PR TITLE
Add template to address standardized rights.

### DIFF
--- a/XSLT/tslaqdctomods.xsl
+++ b/XSLT/tslaqdctomods.xsl
@@ -96,7 +96,6 @@
             </accessCondition>
         </xsl:otherwise>
         </xsl:choose>
-      <xsl:apply-templates/>
     </xsl:template>
   
     <!--identifier-->

--- a/XSLT/tslaqdctomods.xsl
+++ b/XSLT/tslaqdctomods.xsl
@@ -83,14 +83,19 @@
     <!--rights-->
     <xsl:template match="dc:rights">
       <xsl:variable name="vRights" select="normalize-space(.)"/>
-        <xsl:if test="$vRights='Copyright not evaluated: http://rightsstatements.org/vocab/CNE/1.0/'">
+        <xsl:choose>
+        <xsl:when test="$vRights='Copyright not evaluated: http://rightsstatements.org/vocab/CNE/1.0/'">
             <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
-        </xsl:if>
+        </xsl:when>
+            <xsl:when test="$vRights='No copyright - United States: http://rightsstatements.org/vocab/NoC-US/1.0/'">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/NoC-US/1.0/">No Copyright - United States</accessCondition>
+        </xsl:when>
         <xsl:otherwise>
             <accessCondition type="local rights statement">
                 <xsl:apply-templates/>
             </accessCondition>
         </xsl:otherwise>
+        </xsl:choose>
       <xsl:apply-templates/>
     </xsl:template>
   

--- a/XSLT/tslaqdctomods.xsl
+++ b/XSLT/tslaqdctomods.xsl
@@ -58,9 +58,8 @@
                     <xsl:apply-templates select="dc:title/text()"/>
                 </title>
             </titleInfo>
-            <accessCondition type="local rights statement">
-              <xsl:apply-templates select="dc:rights"/>
-            </accessCondition>
+          <!-- rights -->
+          <xsl:apply-templates select="dc:rights"/>
           <location>
             <xsl:apply-templates select="dc:identifier[starts-with(., 'http://')]"/>
           </location>
@@ -83,6 +82,15 @@
     
     <!--rights-->
     <xsl:template match="dc:rights">
+      <xsl:variable name="vRights" select="normalize-space(.)"/>
+        <xsl:if test="$vRights='Copyright not evaluated: http://rightsstatements.org/vocab/CNE/1.0/'">
+            <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
+        </xsl:if>
+        <xsl:otherwise>
+            <accessCondition type="local rights statement">
+                <xsl:apply-templates/>
+            </accessCondition>
+        </xsl:otherwise>
       <xsl:apply-templates/>
     </xsl:template>
   


### PR DESCRIPTION
**GitHub Issue**: [GitHub 60](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/60)

## What does this Pull Request do?

Adds a template for TSLA QDC to MODS for their patterns for standardized rights.

## What's new?

TSLA is submitting standardized rights to us in a way where we need to change how rights are handled.  This attempts to do that.

## How should this be tested?

A description of what steps someone could take to:

* Does the transform validate in Oxygen using th Saxon 8.7 processor
* Using sample XML code, does the pull request doe what is intended
* If you have access to a Repox instance, does applying the pull request and touching all existing XSLT do what is intended.
* If you run a full Scema validation on the feed the transform(s) applies to(using Variety.js and DLTN Metadata QA), does every record have:
	* a titleInfo/title
	* a location/url
	* an accessCondition

## Additional Notes:

I'm at a coffee shop where ssh is blocked, so I haven't tested this. I'll look at it later today.

## Interested parties

@CanOfBees @mlhale7 