### PR TITLE
Correctly address context and preview urls

### DIFF
--- a/XSLT/utkmodstomods.xsl
+++ b/XSLT/utkmodstomods.xsl
@@ -184,21 +184,26 @@
                 constructing elements to avoid copied namespaces.
                 also, i'm a bit lazy.
             -->
-            <xsl:element name="url">
-                <xsl:attribute name="access">
-                    <xsl:value-of select="'object in context'"/>
-                </xsl:attribute>
-                <xsl:attribute name="usage">
-                    <xsl:value-of select="'primary display'"/>
-                </xsl:attribute>
-                <xsl:value-of select="following::identifier[starts-with(.,'http://')]"/>
-            </xsl:element>
-            <xsl:element name="url">
-                <xsl:attribute name="access">
-                    <xsl:value-of select="'preview'"/>
-                </xsl:attribute>
-                <xsl:value-of select="concat(following::identifier[starts-with(.,'http://')],'/datastream/TN/view')"/>
-            </xsl:element>
+            <xsl:if test="not(url[@access='object in context'])">
+                <xsl:element name="url">
+                    <xsl:attribute name="access">
+                        <xsl:value-of select="'object in context'"/>
+                    </xsl:attribute>
+                    <xsl:attribute name="usage">
+                        <xsl:value-of select="'primary display'"/>
+                    </xsl:attribute>
+                    <xsl:value-of select="following::identifier[starts-with(.,'https://')]"/>
+                </xsl:element>
+            </xsl:if>
+            <xsl:if test="not(url[@access='preview'])">
+                <xsl:element name="url">
+                    <xsl:attribute name="access">
+                        <xsl:value-of select="'preview'"/>
+                    </xsl:attribute>
+                    <xsl:value-of select="concat(following::identifier[starts-with(.,'https://')],'/datastream/TN/view')"/>
+                </xsl:element>
+            </xsl:if>
+
         </xsl:copy>
     </xsl:template>
 

--- a/XSLT/utkmodstomods.xsl
+++ b/XSLT/utkmodstomods.xsl
@@ -154,7 +154,8 @@
             <xsl:apply-templates select="@* | node()"/>
         </xsl:copy>
     </xsl:template>
-    
+
+    <!-- ignore preceding or following sibling titleInfos when titleInfo[@supplied] is present -->
     <xsl:template match="titleInfo[preceding-sibling::titleInfo[@supplied] or following-sibling::titleInfo[@supplied]]"/>
 
     <!-- This is a temporary rule to move local accessConditions to abstract and replace all text since it currently has non-UTF8 characters -->


### PR DESCRIPTION
**GitHub Issue: N/A

## What does this Pull Request do?
Adds templating to add (or ignore) `location/url[@access]` elements. Adds additional templating to ignore misspelled `identifer` elements (if present).
 
## What's new?
This should only impact the UTK mods-to-mods stylesheet. 

## How should this be tested?
This should be run with Saxon 8.7 against sample UTK MODS. 

## Interested parties
@markpbaggett 