### PR TITLE
Modify TSLA QDC transform to look for IIIF manifest.

### DIFF
--- a/XSLT/tslaqdctomods.xsl
+++ b/XSLT/tslaqdctomods.xsl
@@ -23,6 +23,7 @@
     dc:language processing parameter: there are multiple language values in the
     QDC.
   -->
+    <xsl:variable name="catalog" select="document('catalog.xml')"/>
 
     <xsl:param name="pLang">
         <l string="eng">english</l>
@@ -61,7 +62,7 @@
           <!-- rights -->
           <xsl:apply-templates select="dc:rights"/>
           <location>
-            <xsl:apply-templates select="dc:identifier[starts-with(., 'http://')]"/>
+            <xsl:apply-templates select="dc:identifier[starts-with(normalize-space(.), 'http://')]"/>
           </location>
           <!-- creator(s) -->
           <xsl:apply-templates select="dc:creator"/>
@@ -99,10 +100,14 @@
     </xsl:template>
   
     <!--identifier-->
-    <xsl:template match="dc:identifier[starts-with(., 'http://')]">
+    <xsl:template match="dc:identifier[starts-with(normalize-space(.), 'http://')]">
       <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
+      <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/info.json')"/>
       <url usage="primary" access="object in context"><xsl:apply-templates/></url>
       <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
+      <xsl:if test="normalize-space(.) = $catalog//@id">
+          <url note="iiif-manifest"><xsl:value-of select="$iiif-manifest"/></url>
+      </xsl:if>
     </xsl:template>
     
     <!-- creator(s) -->


### PR DESCRIPTION
**DLTN GitHub Issue**: [DLTN-75](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/75)
**UTK JIRA Issue**: [DPLA-208](https://jira.lib.utk.edu/browse/DPLA-208)

## What does this Pull Request do?

**WARNING**: this pull request is not ready for merge.  We need to merge the previous p.r. first because it establishes the idea of a catalog.xml.  After it is merged, this p.r. will all include a commit that modifies the initial catalog.xml.

This pull request adds IIIF manifest uris to MODS records for DPLA when the corresponding record has a IIIF mainfest request that generates a 200 response.

## What's new?

1. The TSLA QDC to MODS transform has been modified so that an extra location/url node is created with a note="iiif-manifest" if it has a corresponding match in catalog.xml.
2. Although not present in the initial p.r., it will also include a modification to catalog.xml to include tsla qdc records with manifests.

## How should this be tested?

Once the catalog.xml commit is pushed,

1. Test the transform versus the sample [Fisk.xml](/Sample_Data/State_Library/qdc/Fisk.xml).  It should not get a /mods:location/mods:url[note="iiif-manifest"].
2. Test the transform versus the sample [Mustard.xml](/Sample_Data/State_Library/qdc/Mustard.xml).  It should get a /mods:location/mods:url[note="iiif-manifest"]

## Additional Notes:

Again, there is no catalog yet.  Review, approve, and merge the first p.r. first.

## Interested parties

@mlhale7 