### PR TITLE
Fix broken issue link in template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
-**GitHub Issue: [link](link)
+**GitHub Issue**: [link](link)
+**Jira Issue**: []()
 
 * Other Relevant Links (OAI Feeds, DPLA Records, Metadata Mappings, DLTN Documentation, Etc.)
 


### PR DESCRIPTION
**GitHub Issue**: [DLTN_XSLT-83](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/83)

## What does this Pull Request do?

This fixes the broken link we've had for years and adds a new Jira link to the template.

## What's new?

It's really as simple as it says above.

## How should this be tested?

Look at files changed.  Does it look okay?

## Interested parties

@mlhale7 @CanOfBees 