### PR TITLE
Add memphis world test.

### DIFF
--- a/Sample_Data/Crossroads/memphis_world.xml
+++ b/Sample_Data/Crossroads/memphis_world.xml
@@ -1,0 +1,14053 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/style.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2019-01-25T12:44:40Z</responseDate><request verb="ListRecords" metadataPrefix="xoai" set="col_10267_31334">http://dlynx.rhodes.edu:8080/oai/request</request><ListRecords><record><header><identifier>oai:dlynx.rhodes.edu:10267/33180</identifier><datestamp>2018-05-14T19:38:14Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-23T14:12:31Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-23T14:12:31Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1957-07-06</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33180</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v26n48_1957-07-06</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1957 July 6th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v26n48_1957-07-06.pdf.txt</field>
+<field name="originalName">MW_v26n48_1957-07-06.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33180/3/MW_v26n48_1957-07-06.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v26n48_1957-07-06.txt.txt</field>
+<field name="originalName">MW_v26n48_1957-07-06.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">113533</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33180/5/MW_v26n48_1957-07-06.txt.txt</field>
+<field name="checksum">8edf682a6cd035af3dc05c2bef1455b8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v26n48_1957-07-06.pdf.jpg</field>
+<field name="originalName">MW_v26n48_1957-07-06.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27255</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33180/4/MW_v26n48_1957-07-06.pdf.jpg</field>
+<field name="checksum">15dd68340f5277acc599e12eb9808d5b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v26n48_1957-07-06.pdf</field>
+<field name="originalName">MW_v26n48_1957-07-06.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">33341455</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33180/1/MW_v26n48_1957-07-06.pdf</field>
+<field name="checksum">4ea7d5eea1515e4f8f92bb0b5e760c0b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v26n48_1957-07-06.txt</field>
+<field name="originalName">MW_v26n48_1957-07-06.txt</field>
+<field name="format">text/plain</field>
+<field name="size">113540</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33180/2/MW_v26n48_1957-07-06.txt</field>
+<field name="checksum">1bc8da69d94a408e20f37eb817da0b44</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33180</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33180</field>
+<field name="lastModifyDate">2018-05-14 14:38:14.138</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31899</identifier><datestamp>2018-05-14T19:35:37Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-15T22:40:54Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-15T22:40:54Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1951-04-20</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31899</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v19n87_1951-04-20</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1951 April 20th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n87_1951-04-20.pdf.txt</field>
+<field name="originalName">MW_v19n87_1951-04-20.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31899/3/MW_v19n87_1951-04-20.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n87_1951-04-20.txt.txt</field>
+<field name="originalName">MW_v19n87_1951-04-20.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">22707</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31899/5/MW_v19n87_1951-04-20.txt.txt</field>
+<field name="checksum">aa1522ec37f65ccda3bb7e704ec67c23</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n87_1951-04-20.pdf.jpg</field>
+<field name="originalName">MW_v19n87_1951-04-20.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27767</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31899/4/MW_v19n87_1951-04-20.pdf.jpg</field>
+<field name="checksum">1cb33bc52b5da39b9096b20db2fe7c75</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n87_1951-04-20.pdf</field>
+<field name="originalName">MW_v19n87_1951-04-20.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">35852806</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31899/1/MW_v19n87_1951-04-20.pdf</field>
+<field name="checksum">3f57be33af8c996e38076d59a580bd32</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n87_1951-04-20.txt</field>
+<field name="originalName">MW_v19n87_1951-04-20.txt</field>
+<field name="format">text/plain</field>
+<field name="size">22704</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31899/2/MW_v19n87_1951-04-20.txt</field>
+<field name="checksum">09177fe2d27757f4a3768ebabb6f5e52</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31899</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31899</field>
+<field name="lastModifyDate">2018-05-14 14:35:37.357</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32031</identifier><datestamp>2018-05-14T19:36:52Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:54:35Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:54:35Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1952-09-26</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32031</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v21n13_1952-09-26</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1952 September 26th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n13_1952-09-26.pdf.txt</field>
+<field name="originalName">MW_v21n13_1952-09-26.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32031/3/MW_v21n13_1952-09-26.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v21n13_1952-09-26.txt.txt</field>
+<field name="originalName">MW_v21n13_1952-09-26.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">131928</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32031/5/MW_v21n13_1952-09-26.txt.txt</field>
+<field name="checksum">78881161b8d742d5a103aa46bd16a832</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n13_1952-09-26.pdf.jpg</field>
+<field name="originalName">MW_v21n13_1952-09-26.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26611</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32031/4/MW_v21n13_1952-09-26.pdf.jpg</field>
+<field name="checksum">61c125c5217ed88ca2b09a870ae01846</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n13_1952-09-26.pdf</field>
+<field name="originalName">MW_v21n13_1952-09-26.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">49300014</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32031/1/MW_v21n13_1952-09-26.pdf</field>
+<field name="checksum">39e1c9879c65e3ed7699d1bda792b275</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v21n13_1952-09-26.txt</field>
+<field name="originalName">MW_v21n13_1952-09-26.txt</field>
+<field name="format">text/plain</field>
+<field name="size">131970</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32031/2/MW_v21n13_1952-09-26.txt</field>
+<field name="checksum">61044c7c1b56e3ddcb072c6063e41de6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32031</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32031</field>
+<field name="lastModifyDate">2018-05-14 14:36:52.611</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31638</identifier><datestamp>2018-05-14T18:57:33Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:23Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:23Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-02-24</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31638</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v18n70_1950-02-24</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 February 24th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n70_1950-02-24.pdf.txt</field>
+<field name="originalName">MW_v18n70_1950-02-24.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31638/3/MW_v18n70_1950-02-24.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n70_1950-02-24.txt.txt</field>
+<field name="originalName">MW_v18n70_1950-02-24.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">89982</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31638/5/MW_v18n70_1950-02-24.txt.txt</field>
+<field name="checksum">cde9ede17ce3e2eaf481c6c12e892a2b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n70_1950-02-24.pdf.jpg</field>
+<field name="originalName">MW_v18n70_1950-02-24.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">19908</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31638/4/MW_v18n70_1950-02-24.pdf.jpg</field>
+<field name="checksum">bedcbbb685036a946dc711d005375f60</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n70_1950-02-24.pdf</field>
+<field name="originalName">MW_v18n70_1950-02-24.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">21442260</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31638/1/MW_v18n70_1950-02-24.pdf</field>
+<field name="checksum">21de4590d4c65236d12c8f83be91eb1d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n70_1950-02-24.txt</field>
+<field name="originalName">MW_v18n70_1950-02-24.txt</field>
+<field name="format">text/plain</field>
+<field name="size">89978</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31638/2/MW_v18n70_1950-02-24.txt</field>
+<field name="checksum">93a87d97a95a5cef581542a8f147c5c0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31638</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31638</field>
+<field name="lastModifyDate">2018-05-14 13:57:33.169</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33050</identifier><datestamp>2018-05-14T18:46:10Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:26:45Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:26:45Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1967-07-22</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33050</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v36n4_1967-07-22</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1967 July 22nd</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n4_1967-07-22.pdf.txt</field>
+<field name="originalName">MW_v36n4_1967-07-22.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33050/3/MW_v36n4_1967-07-22.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v36n4_1967-07-22.txt.txt</field>
+<field name="originalName">MW_v36n4_1967-07-22.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">70096</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33050/5/MW_v36n4_1967-07-22.txt.txt</field>
+<field name="checksum">7a2057541d0e96e7e83f1ace29bd6cd5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n4_1967-07-22.pdf.jpg</field>
+<field name="originalName">MW_v36n4_1967-07-22.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">20847</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33050/4/MW_v36n4_1967-07-22.pdf.jpg</field>
+<field name="checksum">c25f95a753150987bab03183310138ee</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n4_1967-07-22.pdf</field>
+<field name="originalName">MW_v36n4_1967-07-22.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32166878</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33050/1/MW_v36n4_1967-07-22.pdf</field>
+<field name="checksum">92f4f51b1a82ee752b9a7fe9fa675504</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v36n4_1967-07-22.txt</field>
+<field name="originalName">MW_v36n4_1967-07-22.txt</field>
+<field name="format">text/plain</field>
+<field name="size">70100</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33050/2/MW_v36n4_1967-07-22.txt</field>
+<field name="checksum">176b0af7cbddb2b3915b6d253dae65f1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33050</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33050</field>
+<field name="lastModifyDate">2018-05-14 13:46:10.041</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31871</identifier><datestamp>2018-05-14T19:35:37Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-15T22:40:50Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-15T22:40:50Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1951-12-28</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31871</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v20n53_1951-12-28</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1951 December 28th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n53_1951-12-28.txt</field>
+<field name="originalName">MW_v20n53_1951-12-28.txt</field>
+<field name="format">text/plain</field>
+<field name="size">135060</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31871/1/MW_v20n53_1951-12-28.txt</field>
+<field name="checksum">5e47602bd38bc21aff25777432e71918</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n53_1951-12-28.pdf</field>
+<field name="originalName">MW_v20n53_1951-12-28.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">40098512</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31871/2/MW_v20n53_1951-12-28.pdf</field>
+<field name="checksum">6e378e1700994b9a13ba80a31b892227</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n53_1951-12-28.txt.txt</field>
+<field name="originalName">MW_v20n53_1951-12-28.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">135004</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31871/3/MW_v20n53_1951-12-28.txt.txt</field>
+<field name="checksum">75f451ebe61420c74ea30417be67ffe4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n53_1951-12-28.pdf.txt</field>
+<field name="originalName">MW_v20n53_1951-12-28.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31871/4/MW_v20n53_1951-12-28.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n53_1951-12-28.pdf.jpg</field>
+<field name="originalName">MW_v20n53_1951-12-28.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27648</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31871/5/MW_v20n53_1951-12-28.pdf.jpg</field>
+<field name="checksum">9dbed6ebf6e4bc6c4b274ab40eb05659</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31871</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31871</field>
+<field name="lastModifyDate">2018-05-14 14:35:37.046</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32625</identifier><datestamp>2018-05-14T19:21:42Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-09T16:16:25Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-09T16:16:25Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1959-08-29</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32625</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v29n12_1959-08-29</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1959 August 29th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n12_1959-08-29.txt</field>
+<field name="originalName">MW_v29n12_1959-08-29.txt</field>
+<field name="format">text/plain</field>
+<field name="size">100058</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32625/1/MW_v29n12_1959-08-29.txt</field>
+<field name="checksum">2f57343efeb790f6faa0f99ffe0a084b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v29n12_1959-08-29.pdf</field>
+<field name="originalName">MW_v29n12_1959-08-29.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">43522863</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32625/2/MW_v29n12_1959-08-29.pdf</field>
+<field name="checksum">c3c5b43cb1ed73113dc08cbe6eec13e7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n12_1959-08-29.txt.txt</field>
+<field name="originalName">MW_v29n12_1959-08-29.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">100053</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32625/3/MW_v29n12_1959-08-29.txt.txt</field>
+<field name="checksum">f507eddf331e7425581727fce6963650</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v29n12_1959-08-29.pdf.txt</field>
+<field name="originalName">MW_v29n12_1959-08-29.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32625/4/MW_v29n12_1959-08-29.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n12_1959-08-29.pdf.jpg</field>
+<field name="originalName">MW_v29n12_1959-08-29.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27709</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32625/5/MW_v29n12_1959-08-29.pdf.jpg</field>
+<field name="checksum">704a49dc92a9f2fe5b83e1735dde8247</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32625</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32625</field>
+<field name="lastModifyDate">2018-05-14 14:21:42.447</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31990</identifier><datestamp>2018-05-14T19:36:51Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:54:30Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:54:30Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1952-01-25</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31990</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v20n61_1952-01-25</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1952 January 25th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n61_1952-01-25.pdf</field>
+<field name="originalName">MW_v20n61_1952-01-25.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">41756961</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31990/1/MW_v20n61_1952-01-25.pdf</field>
+<field name="checksum">0b39c2d722cae8cf84039574bb93ba99</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n61_1952-01-25.txt</field>
+<field name="originalName">MW_v20n61_1952-01-25.txt</field>
+<field name="format">text/plain</field>
+<field name="size">129188</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31990/2/MW_v20n61_1952-01-25.txt</field>
+<field name="checksum">f595348b1e685ac74006c4cdfa00a434</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n61_1952-01-25.pdf.txt</field>
+<field name="originalName">MW_v20n61_1952-01-25.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31990/3/MW_v20n61_1952-01-25.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n61_1952-01-25.txt.txt</field>
+<field name="originalName">MW_v20n61_1952-01-25.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">129108</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31990/5/MW_v20n61_1952-01-25.txt.txt</field>
+<field name="checksum">12ae0270c6ea4f8ec2e7be085dd3d523</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n61_1952-01-25.pdf.jpg</field>
+<field name="originalName">MW_v20n61_1952-01-25.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26886</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31990/4/MW_v20n61_1952-01-25.pdf.jpg</field>
+<field name="checksum">d015f900659fe7750962941c8f8cff0b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31990</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31990</field>
+<field name="lastModifyDate">2018-05-14 14:36:51.327</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31887</identifier><datestamp>2018-05-14T19:35:38Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-15T22:40:53Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-15T22:40:53Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1951-03-09</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31887</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v19n75_1951-03-09</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1951 March 9th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n75_1951-03-09.pdf.txt</field>
+<field name="originalName">MW_v19n75_1951-03-09.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31887/3/MW_v19n75_1951-03-09.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n75_1951-03-09.txt.txt</field>
+<field name="originalName">MW_v19n75_1951-03-09.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">66064</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31887/5/MW_v19n75_1951-03-09.txt.txt</field>
+<field name="checksum">d86d4ca8b0f557007b7a0793e9cc521d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n75_1951-03-09.pdf.jpg</field>
+<field name="originalName">MW_v19n75_1951-03-09.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">28959</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31887/4/MW_v19n75_1951-03-09.pdf.jpg</field>
+<field name="checksum">4042d6eaf18ae906f3eb0d6a8049f984</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n75_1951-03-09.pdf</field>
+<field name="originalName">MW_v19n75_1951-03-09.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">37123785</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31887/2/MW_v19n75_1951-03-09.pdf</field>
+<field name="checksum">e9470a6992b12c20b2f6e548b6511508</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n75_1951-03-09.txt</field>
+<field name="originalName">MW_v19n75_1951-03-09.txt</field>
+<field name="format">text/plain</field>
+<field name="size">66060</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31887/1/MW_v19n75_1951-03-09.txt</field>
+<field name="checksum">507bf75f1c136ea4d4f8f97232313a46</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31887</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31887</field>
+<field name="lastModifyDate">2018-05-14 14:35:38.009</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32752</identifier><datestamp>2018-05-14T18:46:03Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:18:46Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:18:46Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1960-11-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32752</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v30n36_1960-11-30</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1960 November 30th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n36_1960-11-30.txt</field>
+<field name="originalName">MW_v30n36_1960-11-30.txt</field>
+<field name="format">text/plain</field>
+<field name="size">153098</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32752/1/MW_v30n36_1960-11-30.txt</field>
+<field name="checksum">e3a81f8773aada99c5cb61720981def3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n36_1960-11-30.pdf</field>
+<field name="originalName">MW_v30n36_1960-11-30.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">33723152</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32752/2/MW_v30n36_1960-11-30.pdf</field>
+<field name="checksum">749f8070b3eb961e4f7e65ad0818d339</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n36_1960-11-30.txt.txt</field>
+<field name="originalName">MW_v30n36_1960-11-30.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">153105</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32752/3/MW_v30n36_1960-11-30.txt.txt</field>
+<field name="checksum">37bd2945808710c913a683377fe6cb42</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n36_1960-11-30.pdf.txt</field>
+<field name="originalName">MW_v30n36_1960-11-30.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32752/4/MW_v30n36_1960-11-30.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n36_1960-11-30.pdf.jpg</field>
+<field name="originalName">MW_v30n36_1960-11-30.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21238</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32752/5/MW_v30n36_1960-11-30.pdf.jpg</field>
+<field name="checksum">97bdd15f615677a4eae448582c2ebdec</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32752</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32752</field>
+<field name="lastModifyDate">2018-05-14 13:46:03.752</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32817</identifier><datestamp>2018-05-14T18:46:09Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:22:54Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:22:54Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1963-04-06</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32817</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v31n42_1963-04-06</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1963 April 6th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n42_1963-04-06.txt</field>
+<field name="originalName">MW_v31n42_1963-04-06.txt</field>
+<field name="format">text/plain</field>
+<field name="size">171686</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32817/1/MW_v31n42_1963-04-06.txt</field>
+<field name="checksum">c6990b1c69dc456659227ce05c2a1271</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v31n42_1963-04-06.pdf</field>
+<field name="originalName">MW_v31n42_1963-04-06.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">39034859</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32817/2/MW_v31n42_1963-04-06.pdf</field>
+<field name="checksum">50bfd3763cc3c6294d8ef099aa761a5b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n42_1963-04-06.txt.txt</field>
+<field name="originalName">MW_v31n42_1963-04-06.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">171666</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32817/3/MW_v31n42_1963-04-06.txt.txt</field>
+<field name="checksum">e7ad736d73a92598f06eeac63363ec9d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v31n42_1963-04-06.pdf.txt</field>
+<field name="originalName">MW_v31n42_1963-04-06.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32817/4/MW_v31n42_1963-04-06.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n42_1963-04-06.pdf.jpg</field>
+<field name="originalName">MW_v31n42_1963-04-06.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">22415</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32817/5/MW_v31n42_1963-04-06.pdf.jpg</field>
+<field name="checksum">395db40aaba0266aebd9174d6da03bd5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32817</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32817</field>
+<field name="lastModifyDate">2018-05-14 13:46:09.013</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32788</identifier><datestamp>2018-05-14T18:46:09Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:22:03Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:22:03Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1962-08-25</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32788</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v31n10_1962-08-25</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1962 August 25th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n10_1962-08-25.txt</field>
+<field name="originalName">MW_v31n10_1962-08-25.txt</field>
+<field name="format">text/plain</field>
+<field name="size">73464</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32788/1/MW_v31n10_1962-08-25.txt</field>
+<field name="checksum">5d524e0a185f5c3b6ad6b28d5c4e6d44</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v31n10_1962-08-25.pdf</field>
+<field name="originalName">MW_v31n10_1962-08-25.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">33248425</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32788/2/MW_v31n10_1962-08-25.pdf</field>
+<field name="checksum">42fe5bdd14a919a87ac10cc6e75cc315</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n10_1962-08-25.txt.txt</field>
+<field name="originalName">MW_v31n10_1962-08-25.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">73469</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32788/3/MW_v31n10_1962-08-25.txt.txt</field>
+<field name="checksum">bfd4a0dabf494b8e98af9969d605dc5e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v31n10_1962-08-25.pdf.txt</field>
+<field name="originalName">MW_v31n10_1962-08-25.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32788/4/MW_v31n10_1962-08-25.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n10_1962-08-25.pdf.jpg</field>
+<field name="originalName">MW_v31n10_1962-08-25.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21825</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32788/5/MW_v31n10_1962-08-25.pdf.jpg</field>
+<field name="checksum">b0b794fcc4c7a85980c290e196dfd18f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32788</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32788</field>
+<field name="lastModifyDate">2018-05-14 13:46:09.774</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31897</identifier><datestamp>2018-05-14T19:35:38Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-15T22:40:54Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-15T22:40:54Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1951-04-13</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31897</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v19n85_1951-04-13</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1951 April 13th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n85_1951-04-13.pdf.txt</field>
+<field name="originalName">MW_v19n85_1951-04-13.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31897/3/MW_v19n85_1951-04-13.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n85_1951-04-13.txt.txt</field>
+<field name="originalName">MW_v19n85_1951-04-13.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">48209</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31897/5/MW_v19n85_1951-04-13.txt.txt</field>
+<field name="checksum">5bec74d2d32d187716ae743755d6328e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n85_1951-04-13.pdf.jpg</field>
+<field name="originalName">MW_v19n85_1951-04-13.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27164</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31897/4/MW_v19n85_1951-04-13.pdf.jpg</field>
+<field name="checksum">6468733d7ac73402058847e8172a6900</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n85_1951-04-13.pdf</field>
+<field name="originalName">MW_v19n85_1951-04-13.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">39488042</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31897/2/MW_v19n85_1951-04-13.pdf</field>
+<field name="checksum">0f482412f79b533f280ac11a0eeaae98</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n85_1951-04-13.txt</field>
+<field name="originalName">MW_v19n85_1951-04-13.txt</field>
+<field name="format">text/plain</field>
+<field name="size">48210</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31897/1/MW_v19n85_1951-04-13.txt</field>
+<field name="checksum">04b637adb7cc72598df740db8bb4a9d8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31897</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31897</field>
+<field name="lastModifyDate">2018-05-14 14:35:38.073</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32474</identifier><datestamp>2018-05-14T19:25:35Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:22:04Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:22:04Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1958-04-12</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32474</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v27n76_1958-04-12</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1958 April 12th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n76_1958-04-12.pdf</field>
+<field name="originalName">MW_v27n76_1958-04-12.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">33081483</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32474/1/MW_v27n76_1958-04-12.pdf</field>
+<field name="checksum">fe1442f73b15ba9ab37accb4550a880f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v27n76_1958-04-12.txt</field>
+<field name="originalName">MW_v27n76_1958-04-12.txt</field>
+<field name="format">text/plain</field>
+<field name="size">104592</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32474/2/MW_v27n76_1958-04-12.txt</field>
+<field name="checksum">c640953701d905a6e748893afa271629</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n76_1958-04-12.pdf.txt</field>
+<field name="originalName">MW_v27n76_1958-04-12.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32474/3/MW_v27n76_1958-04-12.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v27n76_1958-04-12.txt.txt</field>
+<field name="originalName">MW_v27n76_1958-04-12.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">104595</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32474/5/MW_v27n76_1958-04-12.txt.txt</field>
+<field name="checksum">7a75516f0ee1254717c86dda6cb737e4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n76_1958-04-12.pdf.jpg</field>
+<field name="originalName">MW_v27n76_1958-04-12.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26332</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32474/4/MW_v27n76_1958-04-12.pdf.jpg</field>
+<field name="checksum">2174906de21fa7ba4585faba3eb87013</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32474</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32474</field>
+<field name="lastModifyDate">2018-05-14 14:25:35.833</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32287</identifier><datestamp>2018-05-14T19:40:06Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-02T15:18:11Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-02T15:18:11Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1954-05-14</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32287</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v22n74_1954-05-14</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1954 May 14th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n74_1954-05-14.pdf</field>
+<field name="originalName">MW_v22n74_1954-05-14.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">35900702</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32287/1/MW_v22n74_1954-05-14.pdf</field>
+<field name="checksum">7a18149dcd1f123ea8f24a0cfc2de1db</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v22n74_1954-05-14.txt</field>
+<field name="originalName">MW_v22n74_1954-05-14.txt</field>
+<field name="format">text/plain</field>
+<field name="size">72480</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32287/2/MW_v22n74_1954-05-14.txt</field>
+<field name="checksum">b120e780625e0e2637b9130be8d2239f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n74_1954-05-14.pdf.txt</field>
+<field name="originalName">MW_v22n74_1954-05-14.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32287/3/MW_v22n74_1954-05-14.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v22n74_1954-05-14.txt.txt</field>
+<field name="originalName">MW_v22n74_1954-05-14.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">72469</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32287/5/MW_v22n74_1954-05-14.txt.txt</field>
+<field name="checksum">6513ba52439fe6185404be719376cc90</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n74_1954-05-14.pdf.jpg</field>
+<field name="originalName">MW_v22n74_1954-05-14.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26953</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32287/4/MW_v22n74_1954-05-14.pdf.jpg</field>
+<field name="checksum">1632e7e8aa1dd6b71726f1e9127575d4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32287</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32287</field>
+<field name="lastModifyDate">2018-05-14 14:40:06.115</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32456</identifier><datestamp>2018-05-14T19:25:36Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:22:02Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:22:02Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1958-02-08</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32456</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v27n58_1958-02-08</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1958 February 8th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n58_1958-02-08.txt.txt</field>
+<field name="originalName">MW_v27n58_1958-02-08.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">90237</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32456/3/MW_v27n58_1958-02-08.txt.txt</field>
+<field name="checksum">92f3e893e4fdfa7848bb8794954bb1ae</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v27n58_1958-02-08.pdf.txt</field>
+<field name="originalName">MW_v27n58_1958-02-08.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32456/4/MW_v27n58_1958-02-08.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n58_1958-02-08.pdf.jpg</field>
+<field name="originalName">MW_v27n58_1958-02-08.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26853</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32456/5/MW_v27n58_1958-02-08.pdf.jpg</field>
+<field name="checksum">02006f0923504ecb8af00bf6a04785d2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n58_1958-02-08.txt</field>
+<field name="originalName">MW_v27n58_1958-02-08.txt</field>
+<field name="format">text/plain</field>
+<field name="size">90242</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32456/1/MW_v27n58_1958-02-08.txt</field>
+<field name="checksum">362719d014bc25d290417905c1f673e1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v27n58_1958-02-08.pdf</field>
+<field name="originalName">MW_v27n58_1958-02-08.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">30988962</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32456/2/MW_v27n58_1958-02-08.pdf</field>
+<field name="checksum">344821bb08b81ccfb928a8d6cabd9251</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32456</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32456</field>
+<field name="lastModifyDate">2018-05-14 14:25:36.23</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32944</identifier><datestamp>2018-05-14T18:46:08Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:25:07Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:25:07Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1965-11-20</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32944</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v34n20_1965-11-20</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1965 November 20th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v34n20_1965-11-20.txt</field>
+<field name="originalName">MW_v34n20_1965-11-20.txt</field>
+<field name="format">text/plain</field>
+<field name="size">46220</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32944/1/MW_v34n20_1965-11-20.txt</field>
+<field name="checksum">1b7fa543e6b9418aa7b2eb5386ef28b7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v34n20_1965-11-20.pdf</field>
+<field name="originalName">MW_v34n20_1965-11-20.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">31231600</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32944/2/MW_v34n20_1965-11-20.pdf</field>
+<field name="checksum">01e674b1c764dbc2b1bbffdff78e2cb5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v34n20_1965-11-20.txt.txt</field>
+<field name="originalName">MW_v34n20_1965-11-20.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">46222</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32944/3/MW_v34n20_1965-11-20.txt.txt</field>
+<field name="checksum">800cfdabbb5d92e59beffe93b6b26496</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v34n20_1965-11-20.pdf.txt</field>
+<field name="originalName">MW_v34n20_1965-11-20.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32944/4/MW_v34n20_1965-11-20.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v34n20_1965-11-20.pdf.jpg</field>
+<field name="originalName">MW_v34n20_1965-11-20.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21727</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32944/5/MW_v34n20_1965-11-20.pdf.jpg</field>
+<field name="checksum">24f739aa02504a69abaf4bf39960a7e9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32944</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32944</field>
+<field name="lastModifyDate">2018-05-14 13:46:08.207</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32769</identifier><datestamp>2018-05-14T18:46:08Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:21:05Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:21:05Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1961-09-23</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32769</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v30n15_1961-09-23</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1961 September 23rd</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n15_1961-09-23.pdf</field>
+<field name="originalName">MW_v30n15_1961-09-23.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">34532092</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32769/1/MW_v30n15_1961-09-23.pdf</field>
+<field name="checksum">c667ab61df4abe70229f054f593eb023</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n15_1961-09-23.txt</field>
+<field name="originalName">MW_v30n15_1961-09-23.txt</field>
+<field name="format">text/plain</field>
+<field name="size">188422</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32769/2/MW_v30n15_1961-09-23.txt</field>
+<field name="checksum">0618547d025fcfb27257272fb3be9c2c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n15_1961-09-23.pdf.txt</field>
+<field name="originalName">MW_v30n15_1961-09-23.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32769/3/MW_v30n15_1961-09-23.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n15_1961-09-23.txt.txt</field>
+<field name="originalName">MW_v30n15_1961-09-23.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">188419</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32769/5/MW_v30n15_1961-09-23.txt.txt</field>
+<field name="checksum">4577b857a4e6352aa548f6d9e06b7351</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n15_1961-09-23.pdf.jpg</field>
+<field name="originalName">MW_v30n15_1961-09-23.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">22998</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32769/4/MW_v30n15_1961-09-23.pdf.jpg</field>
+<field name="checksum">bd4f8df04d4055dbf60495a636aca979</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32769</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32769</field>
+<field name="lastModifyDate">2018-05-14 13:46:08.518</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31649</identifier><datestamp>2018-05-14T18:57:34Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:24Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:24Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-04-04</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31649</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v18n81_1950-04-04</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 April 4th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n81_1950-04-04.txt</field>
+<field name="originalName">MW_v18n81_1950-04-04.txt</field>
+<field name="format">text/plain</field>
+<field name="size">140998</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31649/1/MW_v18n81_1950-04-04.txt</field>
+<field name="checksum">80b31744778c846d59dedf54ee73a27d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n81_1950-04-04.pdf</field>
+<field name="originalName">MW_v18n81_1950-04-04.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">23015150</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31649/2/MW_v18n81_1950-04-04.pdf</field>
+<field name="checksum">694e0d934d1b35e41e419ceeb0e0b3fb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n81_1950-04-04.txt.txt</field>
+<field name="originalName">MW_v18n81_1950-04-04.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">140991</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31649/3/MW_v18n81_1950-04-04.txt.txt</field>
+<field name="checksum">6918c47d5d26297c7438c1007dc6aa63</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n81_1950-04-04.pdf.txt</field>
+<field name="originalName">MW_v18n81_1950-04-04.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31649/4/MW_v18n81_1950-04-04.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n81_1950-04-04.pdf.jpg</field>
+<field name="originalName">MW_v18n81_1950-04-04.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">20405</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31649/5/MW_v18n81_1950-04-04.pdf.jpg</field>
+<field name="checksum">f7b763c7b986ff96e8788396e1638d97</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31649</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31649</field>
+<field name="lastModifyDate">2018-05-14 13:57:34.57</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33018</identifier><datestamp>2018-05-14T18:46:11Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:26:43Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:26:43Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1967-04-15</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33018</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v35n42_1967-04-15</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1967 April 15th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v35n42_1967-04-15.pdf</field>
+<field name="originalName">MW_v35n42_1967-04-15.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32430427</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33018/1/MW_v35n42_1967-04-15.pdf</field>
+<field name="checksum">f926ace9cde0b30a6e1aa53ea3a41c14</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v35n42_1967-04-15.txt</field>
+<field name="originalName">MW_v35n42_1967-04-15.txt</field>
+<field name="format">text/plain</field>
+<field name="size">94946</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33018/2/MW_v35n42_1967-04-15.txt</field>
+<field name="checksum">4bfc193a0660db9ad3a6eec3959388ff</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v35n42_1967-04-15.pdf.txt</field>
+<field name="originalName">MW_v35n42_1967-04-15.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33018/3/MW_v35n42_1967-04-15.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v35n42_1967-04-15.txt.txt</field>
+<field name="originalName">MW_v35n42_1967-04-15.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">94947</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33018/5/MW_v35n42_1967-04-15.txt.txt</field>
+<field name="checksum">b587534daf4206b902bc1765f48c1218</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v35n42_1967-04-15.pdf.jpg</field>
+<field name="originalName">MW_v35n42_1967-04-15.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21169</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33018/4/MW_v35n42_1967-04-15.pdf.jpg</field>
+<field name="checksum">bf39d92e8ab54bc7a75434f4b9273514</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33018</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33018</field>
+<field name="lastModifyDate">2018-05-14 13:46:11.51</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32133</identifier><datestamp>2018-05-14T19:40:04Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:58:41Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:58:41Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1956-07-25</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32133</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v25n2_1956-07-25</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1956 July 25th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v25n2_1956-07-25.pdf.txt</field>
+<field name="originalName">MW_v25n2_1956-07-25.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32133/3/MW_v25n2_1956-07-25.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v25n2_1956-07-25.txt.txt</field>
+<field name="originalName">MW_v25n2_1956-07-25.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">67679</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32133/5/MW_v25n2_1956-07-25.txt.txt</field>
+<field name="checksum">421c85c456c675334a1d977d96cfb862</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v25n2_1956-07-25.pdf.jpg</field>
+<field name="originalName">MW_v25n2_1956-07-25.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21290</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32133/4/MW_v25n2_1956-07-25.pdf.jpg</field>
+<field name="checksum">40940b0470452e0cf10593fc1a52b5bf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v25n2_1956-07-25.pdf</field>
+<field name="originalName">MW_v25n2_1956-07-25.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">18420253</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32133/1/MW_v25n2_1956-07-25.pdf</field>
+<field name="checksum">eb5dd123fb8f286f3ec2b19d08df0a00</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v25n2_1956-07-25.txt</field>
+<field name="originalName">MW_v25n2_1956-07-25.txt</field>
+<field name="format">text/plain</field>
+<field name="size">67672</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32133/2/MW_v25n2_1956-07-25.txt</field>
+<field name="checksum">b3b23837b059a9dff4567488abfca449</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32133</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32133</field>
+<field name="lastModifyDate">2018-05-14 14:40:04.269</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33205</identifier><datestamp>2018-05-14T19:38:13Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-23T14:12:34Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-23T14:12:34Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1957-10-09</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33205</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v27n23_1957-10-09</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1957 October 9th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n23_1957-10-09.pdf</field>
+<field name="originalName">MW_v27n23_1957-10-09.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">25387415</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33205/1/MW_v27n23_1957-10-09.pdf</field>
+<field name="checksum">f0de5def364999111600644f4c0fef66</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v27n23_1957-10-09.txt</field>
+<field name="originalName">MW_v27n23_1957-10-09.txt</field>
+<field name="format">text/plain</field>
+<field name="size">153822</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33205/2/MW_v27n23_1957-10-09.txt</field>
+<field name="checksum">b6511f2bec5edd4ed013917b27577a54</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n23_1957-10-09.pdf.txt</field>
+<field name="originalName">MW_v27n23_1957-10-09.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33205/3/MW_v27n23_1957-10-09.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v27n23_1957-10-09.txt.txt</field>
+<field name="originalName">MW_v27n23_1957-10-09.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">153793</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33205/5/MW_v27n23_1957-10-09.txt.txt</field>
+<field name="checksum">a96519e19e679a71d73bd6724f7330ef</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n23_1957-10-09.pdf.jpg</field>
+<field name="originalName">MW_v27n23_1957-10-09.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27614</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33205/4/MW_v27n23_1957-10-09.pdf.jpg</field>
+<field name="checksum">43d19075f4ff4291712dd6bbe6c14c49</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33205</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33205</field>
+<field name="lastModifyDate">2018-05-14 14:38:13.239</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32531</identifier><datestamp>2018-05-14T19:25:36Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:22:11Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:22:11Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1958-11-05</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32531</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v28n39_1958-11-05</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1958 November 5th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n39_1958-11-05.pdf</field>
+<field name="originalName">MW_v28n39_1958-11-05.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">24812938</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32531/1/MW_v28n39_1958-11-05.pdf</field>
+<field name="checksum">a87ddb55fc5d7fd136dd2a0951466d45</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n39_1958-11-05.txt</field>
+<field name="originalName">MW_v28n39_1958-11-05.txt</field>
+<field name="format">text/plain</field>
+<field name="size">92494</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32531/2/MW_v28n39_1958-11-05.txt</field>
+<field name="checksum">12690009d881e286042f37e6e0e2aaef</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n39_1958-11-05.pdf.txt</field>
+<field name="originalName">MW_v28n39_1958-11-05.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32531/3/MW_v28n39_1958-11-05.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n39_1958-11-05.txt.txt</field>
+<field name="originalName">MW_v28n39_1958-11-05.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">92496</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32531/5/MW_v28n39_1958-11-05.txt.txt</field>
+<field name="checksum">44932763ce7adfc7845778f4e5f2fd00</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n39_1958-11-05.pdf.jpg</field>
+<field name="originalName">MW_v28n39_1958-11-05.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26560</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32531/4/MW_v28n39_1958-11-05.pdf.jpg</field>
+<field name="checksum">b4038359ab8c67364daf369cb2b8bdaf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32531</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32531</field>
+<field name="lastModifyDate">2018-05-14 14:25:36.458</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33078</identifier><datestamp>2018-05-14T18:54:58Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:28:27Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:28:27Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1970-06-20</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33078</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v38n39_1970-06-20</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1970 June 20th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v38n39_1970-06-20.txt</field>
+<field name="originalName">MW_v38n39_1970-06-20.txt</field>
+<field name="format">text/plain</field>
+<field name="size">46162</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33078/1/MW_v38n39_1970-06-20.txt</field>
+<field name="checksum">dc119308294008cb7ad96ebd2fd56422</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v38n39_1970-06-20.pdf</field>
+<field name="originalName">MW_v38n39_1970-06-20.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">27931673</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33078/2/MW_v38n39_1970-06-20.pdf</field>
+<field name="checksum">ea171da8f60e5a0e2017bdb03026e900</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v38n39_1970-06-20.txt.txt</field>
+<field name="originalName">MW_v38n39_1970-06-20.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">46169</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33078/3/MW_v38n39_1970-06-20.txt.txt</field>
+<field name="checksum">55c7d1a9389599e1f284bfdaa0e7227a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v38n39_1970-06-20.pdf.txt</field>
+<field name="originalName">MW_v38n39_1970-06-20.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33078/4/MW_v38n39_1970-06-20.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v38n39_1970-06-20.pdf.jpg</field>
+<field name="originalName">MW_v38n39_1970-06-20.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">24323</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33078/5/MW_v38n39_1970-06-20.pdf.jpg</field>
+<field name="checksum">fa7749c3a06de6bcb10476a915392275</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33078</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33078</field>
+<field name="lastModifyDate">2018-05-14 13:54:58.102</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32022</identifier><datestamp>2018-05-14T19:36:51Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:54:34Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:54:34Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1952-05-20</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32022</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v20n94_1952-05-20</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1952 May 20th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n94_1952-05-20.pdf</field>
+<field name="originalName">MW_v20n94_1952-05-20.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">40878765</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32022/1/MW_v20n94_1952-05-20.pdf</field>
+<field name="checksum">1ed63d6f22f6220b76851694b9e3cc05</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n94_1952-05-20.txt</field>
+<field name="originalName">MW_v20n94_1952-05-20.txt</field>
+<field name="format">text/plain</field>
+<field name="size">80500</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32022/2/MW_v20n94_1952-05-20.txt</field>
+<field name="checksum">5f2c02fd9ca60a93e144f1570ddaff34</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n94_1952-05-20.pdf.txt</field>
+<field name="originalName">MW_v20n94_1952-05-20.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32022/3/MW_v20n94_1952-05-20.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n94_1952-05-20.txt.txt</field>
+<field name="originalName">MW_v20n94_1952-05-20.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">80500</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32022/5/MW_v20n94_1952-05-20.txt.txt</field>
+<field name="checksum">90e332ef37342b39b856f895542b528a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n94_1952-05-20.pdf.jpg</field>
+<field name="originalName">MW_v20n94_1952-05-20.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26663</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32022/4/MW_v20n94_1952-05-20.pdf.jpg</field>
+<field name="checksum">0dde3896d5532f62e02dd7110f9f5211</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32022</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32022</field>
+<field name="lastModifyDate">2018-05-14 14:36:51.937</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32526</identifier><datestamp>2018-05-14T19:25:35Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:22:10Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:22:10Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1958-10-18</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32526</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v28n34_1958-10-18</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1958 October 18th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n34_1958-10-18.pdf</field>
+<field name="originalName">MW_v28n34_1958-10-18.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">34502188</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32526/1/MW_v28n34_1958-10-18.pdf</field>
+<field name="checksum">1f80e545e325678fd4c61212a9e7db6b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n34_1958-10-18.txt</field>
+<field name="originalName">MW_v28n34_1958-10-18.txt</field>
+<field name="format">text/plain</field>
+<field name="size">133838</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32526/2/MW_v28n34_1958-10-18.txt</field>
+<field name="checksum">6873aad06cab4c5d3f896bd8912895a7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n34_1958-10-18.pdf.txt</field>
+<field name="originalName">MW_v28n34_1958-10-18.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32526/3/MW_v28n34_1958-10-18.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n34_1958-10-18.txt.txt</field>
+<field name="originalName">MW_v28n34_1958-10-18.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">133830</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32526/5/MW_v28n34_1958-10-18.txt.txt</field>
+<field name="checksum">a4a81547badbd3a4cb99dc852fbe5d1d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n34_1958-10-18.pdf.jpg</field>
+<field name="originalName">MW_v28n34_1958-10-18.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27988</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32526/4/MW_v28n34_1958-10-18.pdf.jpg</field>
+<field name="checksum">9cd0f75aee7da09a741fa655e05ff7ca</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32526</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32526</field>
+<field name="lastModifyDate">2018-05-14 14:25:35.501</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32324</identifier><datestamp>2018-05-14T19:40:07Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-02T15:18:15Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-02T15:18:15Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1954-10-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32324</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v23n33_1954-10-19</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1954 October 19th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n33_1954-10-19.pdf.txt</field>
+<field name="originalName">MW_v23n33_1954-10-19.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32324/2/MW_v23n33_1954-10-19.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n33_1954-10-19.pdf.jpg</field>
+<field name="originalName">MW_v23n33_1954-10-19.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">25540</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32324/3/MW_v23n33_1954-10-19.pdf.jpg</field>
+<field name="checksum">78d3420545c553e14a193c43c5078341</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n33_1954-10-19.pdf</field>
+<field name="originalName">MW_v23n33_1954-10-19.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">37500391</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32324/1/MW_v23n33_1954-10-19.pdf</field>
+<field name="checksum">67de29be7475fdf33df4ea444d573cef</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32324</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32324</field>
+<field name="lastModifyDate">2018-05-14 14:40:07.131</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32601</identifier><datestamp>2018-05-14T19:21:42Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-09T16:16:22Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-09T16:16:22Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1959-05-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32601</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v28n97_1959-05-30</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1959 May 30th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n97_1959-05-30.txt</field>
+<field name="originalName">MW_v28n97_1959-05-30.txt</field>
+<field name="format">text/plain</field>
+<field name="size">112114</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32601/1/MW_v28n97_1959-05-30.txt</field>
+<field name="checksum">0599066baa7b6b3d268802668968fbc6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n97_1959-05-30.pdf</field>
+<field name="originalName">MW_v28n97_1959-05-30.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">39639843</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32601/2/MW_v28n97_1959-05-30.pdf</field>
+<field name="checksum">d52bc4b2b98ebf3257716ddb33f1c27f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n97_1959-05-30.txt.txt</field>
+<field name="originalName">MW_v28n97_1959-05-30.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">112106</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32601/3/MW_v28n97_1959-05-30.txt.txt</field>
+<field name="checksum">bcaf168843bad62da23c0584dcec6899</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n97_1959-05-30.pdf.txt</field>
+<field name="originalName">MW_v28n97_1959-05-30.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32601/4/MW_v28n97_1959-05-30.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n97_1959-05-30.pdf.jpg</field>
+<field name="originalName">MW_v28n97_1959-05-30.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27288</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32601/5/MW_v28n97_1959-05-30.pdf.jpg</field>
+<field name="checksum">87284d385d92744a52412e3ad5f24b0b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32601</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32601</field>
+<field name="lastModifyDate">2018-05-14 14:21:42.277</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32302</identifier><datestamp>2018-05-14T19:40:06Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-02T15:18:13Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-02T15:18:13Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1954-07-02</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32302</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v23n1_1954-07-02</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1954 July 2nd</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n1_1954-07-02.pdf</field>
+<field name="originalName">MW_v23n1_1954-07-02.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">39545169</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32302/1/MW_v23n1_1954-07-02.pdf</field>
+<field name="checksum">0a08298add1a91c3b0f2f63743b59992</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n1_1954-07-02.txt</field>
+<field name="originalName">MW_v23n1_1954-07-02.txt</field>
+<field name="format">text/plain</field>
+<field name="size">133292</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32302/2/MW_v23n1_1954-07-02.txt</field>
+<field name="checksum">c96adc0f9781487787ae56a64cf8cdb9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n1_1954-07-02.pdf.txt</field>
+<field name="originalName">MW_v23n1_1954-07-02.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32302/3/MW_v23n1_1954-07-02.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n1_1954-07-02.txt.txt</field>
+<field name="originalName">MW_v23n1_1954-07-02.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">133292</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32302/5/MW_v23n1_1954-07-02.txt.txt</field>
+<field name="checksum">7062d86e3dafd15e611b68966c9f1d38</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n1_1954-07-02.pdf.jpg</field>
+<field name="originalName">MW_v23n1_1954-07-02.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">29022</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32302/4/MW_v23n1_1954-07-02.pdf.jpg</field>
+<field name="checksum">097762e01cb1333248ced940a025bfcb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32302</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32302</field>
+<field name="lastModifyDate">2018-05-14 14:40:06.228</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31647</identifier><datestamp>2018-05-14T18:57:34Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:24Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:24Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-03-28</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31647</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v18n79_1950-03-28</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 March 28th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n79_1950-03-28.pdf</field>
+<field name="originalName">MW_v18n79_1950-03-28.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">15554670</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31647/1/MW_v18n79_1950-03-28.pdf</field>
+<field name="checksum">c8522e884651581e69b3594f518be945</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n79_1950-03-28.txt</field>
+<field name="originalName">MW_v18n79_1950-03-28.txt</field>
+<field name="format">text/plain</field>
+<field name="size">116778</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31647/2/MW_v18n79_1950-03-28.txt</field>
+<field name="checksum">04b067d6df58f046a307b4fc0f77762d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n79_1950-03-28.pdf.txt</field>
+<field name="originalName">MW_v18n79_1950-03-28.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31647/3/MW_v18n79_1950-03-28.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n79_1950-03-28.txt.txt</field>
+<field name="originalName">MW_v18n79_1950-03-28.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">116784</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31647/5/MW_v18n79_1950-03-28.txt.txt</field>
+<field name="checksum">b0aef1874283afb11dc7e234aa8a68e5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n79_1950-03-28.pdf.jpg</field>
+<field name="originalName">MW_v18n79_1950-03-28.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21226</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31647/4/MW_v18n79_1950-03-28.pdf.jpg</field>
+<field name="checksum">13341c561d2936c4e5bd55b2df40a57c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31647</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31647</field>
+<field name="lastModifyDate">2018-05-14 13:57:34.699</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32421</identifier><datestamp>2018-05-14T19:40:08Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:20:59Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:20:59Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1955-09-23</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32421</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v24n29_1955-09-23</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1955 September 23rd</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n29_1955-09-23.pdf</field>
+<field name="originalName">MW_v24n29_1955-09-23.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">49068198</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32421/1/MW_v24n29_1955-09-23.pdf</field>
+<field name="checksum">ff38be9c9fd7ad6c08124500446288b7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v24n29_1955-09-23.txt</field>
+<field name="originalName">MW_v24n29_1955-09-23.txt</field>
+<field name="format">text/plain</field>
+<field name="size">72672</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32421/2/MW_v24n29_1955-09-23.txt</field>
+<field name="checksum">5da5c6314efcb1d32457c88ce1aa5f0c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n29_1955-09-23.pdf.txt</field>
+<field name="originalName">MW_v24n29_1955-09-23.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32421/3/MW_v24n29_1955-09-23.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v24n29_1955-09-23.txt.txt</field>
+<field name="originalName">MW_v24n29_1955-09-23.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">72673</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32421/5/MW_v24n29_1955-09-23.txt.txt</field>
+<field name="checksum">c9321879770435c235891c50f2f06f35</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n29_1955-09-23.pdf.jpg</field>
+<field name="originalName">MW_v24n29_1955-09-23.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">25345</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32421/4/MW_v24n29_1955-09-23.pdf.jpg</field>
+<field name="checksum">0f3525db241c432afea45ca7c38aa89e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32421</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32421</field>
+<field name="lastModifyDate">2018-05-14 14:40:08.908</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31977</identifier><datestamp>2018-05-14T19:36:52Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:54:28Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:54:28Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1952-07-18</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31977</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v20n111_1952-07-18</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1952 July 18th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n111_1952-07-18.pdf</field>
+<field name="originalName">MW_v20n111_1952-07-18.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">41538066</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31977/1/MW_v20n111_1952-07-18.pdf</field>
+<field name="checksum">b5d99c14c988d962a232a5bdc6d790ea</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n111_1952-07-18.txt</field>
+<field name="originalName">MW_v20n111_1952-07-18.txt</field>
+<field name="format">text/plain</field>
+<field name="size">84752</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31977/2/MW_v20n111_1952-07-18.txt</field>
+<field name="checksum">031cc9a559b8d7f9a79c998dc3f02e52</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n111_1952-07-18.pdf.txt</field>
+<field name="originalName">MW_v20n111_1952-07-18.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31977/3/MW_v20n111_1952-07-18.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n111_1952-07-18.txt.txt</field>
+<field name="originalName">MW_v20n111_1952-07-18.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">84749</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31977/5/MW_v20n111_1952-07-18.txt.txt</field>
+<field name="checksum">7a26499c5c2aa85544b7516bd2a55c27</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n111_1952-07-18.pdf.jpg</field>
+<field name="originalName">MW_v20n111_1952-07-18.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27444</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31977/4/MW_v20n111_1952-07-18.pdf.jpg</field>
+<field name="checksum">fe3cf239d8feefef4cc7f82257e75096</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31977</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31977</field>
+<field name="lastModifyDate">2018-05-14 14:36:52.902</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33311</identifier><datestamp>2018-05-14T18:46:14Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-24T17:58:24Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-24T17:58:24Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1969-12-06</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33311</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v38n13_1969-12-06</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1969 December 6th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v38n13_1969-12-06.txt.txt</field>
+<field name="originalName">MW_v38n13_1969-12-06.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">40555</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33311/3/MW_v38n13_1969-12-06.txt.txt</field>
+<field name="checksum">b0250331c5d40ab426c8a6bd613c5c28</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v38n13_1969-12-06.pdf.txt</field>
+<field name="originalName">MW_v38n13_1969-12-06.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33311/4/MW_v38n13_1969-12-06.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v38n13_1969-12-06.pdf.jpg</field>
+<field name="originalName">MW_v38n13_1969-12-06.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">25724</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33311/5/MW_v38n13_1969-12-06.pdf.jpg</field>
+<field name="checksum">8372326ca0243f82c1c973f8d9e927b8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v38n13_1969-12-06.txt</field>
+<field name="originalName">MW_v38n13_1969-12-06.txt</field>
+<field name="format">text/plain</field>
+<field name="size">40548</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33311/1/MW_v38n13_1969-12-06.txt</field>
+<field name="checksum">e33e1a2172224f2b6aa3ec946b0d13c3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v38n13_1969-12-06.pdf</field>
+<field name="originalName">MW_v38n13_1969-12-06.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">33949871</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33311/2/MW_v38n13_1969-12-06.pdf</field>
+<field name="checksum">df780ad82ca525b668b89f935aafaafa</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33311</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33311</field>
+<field name="lastModifyDate">2018-05-14 13:46:14.561</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31356</identifier><datestamp>2018-05-14T18:45:56Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-01-24T21:15:32Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-01-24T21:15:32Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1968-06-01</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31356</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v36n49_1968-06-01</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1968 June 1st</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n49_1968-06-01.pdf</field>
+<field name="originalName">MW_v36n49_1968-06-01.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">21974500</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31356/1/MW_v36n49_1968-06-01.pdf</field>
+<field name="checksum">e8172f7d6270eb8337d9e32ffe96fdbf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v36n49_1968-06-01.txt</field>
+<field name="originalName">MW_v36n49_1968-06-01.txt</field>
+<field name="format">text/plain</field>
+<field name="size">132374</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31356/4/MW_v36n49_1968-06-01.txt</field>
+<field name="checksum">fd32ad0aa241a6675e2569498109ccee</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n49_1968-06-01.pdf.txt</field>
+<field name="originalName">MW_v36n49_1968-06-01.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31356/2/MW_v36n49_1968-06-01.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v36n49_1968-06-01.txt.txt</field>
+<field name="originalName">MW_v36n49_1968-06-01.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">132364</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31356/5/MW_v36n49_1968-06-01.txt.txt</field>
+<field name="checksum">0437f8fcc0aee0bb5ad437eb56119e5e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n49_1968-06-01.pdf.jpg</field>
+<field name="originalName">MW_v36n49_1968-06-01.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">19700</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31356/3/MW_v36n49_1968-06-01.pdf.jpg</field>
+<field name="checksum">69359ba76aa88dbab0cf48f7ce035ecf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31356</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31356</field>
+<field name="lastModifyDate">2018-05-14 13:45:56.986</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31683</identifier><datestamp>2018-05-14T18:57:33Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:27Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:27Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-08-29</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31683</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v19n20_1950-08-29</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 August 29th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n20_1950-08-29.txt</field>
+<field name="originalName">MW_v19n20_1950-08-29.txt</field>
+<field name="format">text/plain</field>
+<field name="size">80132</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31683/1/MW_v19n20_1950-08-29.txt</field>
+<field name="checksum">e33453484c5b14a1310de3e17f610758</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n20_1950-08-29.pdf</field>
+<field name="originalName">MW_v19n20_1950-08-29.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">14512519</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31683/2/MW_v19n20_1950-08-29.pdf</field>
+<field name="checksum">6e8ccd119b7697d5cb82e845cea93ec1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n20_1950-08-29.txt.txt</field>
+<field name="originalName">MW_v19n20_1950-08-29.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">80128</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31683/3/MW_v19n20_1950-08-29.txt.txt</field>
+<field name="checksum">8857ec03ac56684e58c561a6896a23e0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n20_1950-08-29.pdf.txt</field>
+<field name="originalName">MW_v19n20_1950-08-29.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31683/4/MW_v19n20_1950-08-29.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n20_1950-08-29.pdf.jpg</field>
+<field name="originalName">MW_v19n20_1950-08-29.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">19965</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31683/5/MW_v19n20_1950-08-29.pdf.jpg</field>
+<field name="checksum">79d0fc89057118402b48436408cce742</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31683</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31683</field>
+<field name="lastModifyDate">2018-05-14 13:57:33.553</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32703</identifier><datestamp>2018-05-14T18:46:06Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:18:42Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:18:42Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1960-06-04</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32703</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v29n89_1960-06-04</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1960 June 4th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n89_1960-06-04.txt</field>
+<field name="originalName">MW_v29n89_1960-06-04.txt</field>
+<field name="format">text/plain</field>
+<field name="size">92900</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32703/1/MW_v29n89_1960-06-04.txt</field>
+<field name="checksum">4313360a0fa960612b9033b08848b74e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v29n89_1960-06-04.pdf</field>
+<field name="originalName">MW_v29n89_1960-06-04.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">45456164</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32703/2/MW_v29n89_1960-06-04.pdf</field>
+<field name="checksum">9da596eb0ae12419c7264e50aae12f7e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n89_1960-06-04.txt.txt</field>
+<field name="originalName">MW_v29n89_1960-06-04.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">92872</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32703/3/MW_v29n89_1960-06-04.txt.txt</field>
+<field name="checksum">c7aae19cdfdb7d4e2b5632685f41ce02</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v29n89_1960-06-04.pdf.txt</field>
+<field name="originalName">MW_v29n89_1960-06-04.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32703/4/MW_v29n89_1960-06-04.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n89_1960-06-04.pdf.jpg</field>
+<field name="originalName">MW_v29n89_1960-06-04.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">23095</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32703/5/MW_v29n89_1960-06-04.pdf.jpg</field>
+<field name="checksum">32c0d7a9cafa06ae2c5b2efa235e2e7b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32703</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32703</field>
+<field name="lastModifyDate">2018-05-14 13:46:06.114</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32355</identifier><datestamp>2018-05-14T19:40:09Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:20:50Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:20:50Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1955-01-18</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32355</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v23n58_1955-01-18</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1955 January 18th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n58_1955-01-18.pdf.txt</field>
+<field name="originalName">MW_v23n58_1955-01-18.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32355/3/MW_v23n58_1955-01-18.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n58_1955-01-18.txt.txt</field>
+<field name="originalName">MW_v23n58_1955-01-18.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">130814</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32355/5/MW_v23n58_1955-01-18.txt.txt</field>
+<field name="checksum">3161f7af3124ea0d352bcdbeb7db1b88</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n58_1955-01-18.pdf.jpg</field>
+<field name="originalName">MW_v23n58_1955-01-18.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">24985</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32355/4/MW_v23n58_1955-01-18.pdf.jpg</field>
+<field name="checksum">55c8c27ce1b152c39da030fbf32d0ab5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n58_1955-01-18.pdf</field>
+<field name="originalName">MW_v23n58_1955-01-18.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">47494096</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32355/1/MW_v23n58_1955-01-18.pdf</field>
+<field name="checksum">0cbf7b86ee37ad38872640ab7981e4dc</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n58_1955-01-18.txt</field>
+<field name="originalName">MW_v23n58_1955-01-18.txt</field>
+<field name="format">text/plain</field>
+<field name="size">130812</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32355/2/MW_v23n58_1955-01-18.txt</field>
+<field name="checksum">a0fc2a9b7382cf2b852a878522ec0ea5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32355</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32355</field>
+<field name="lastModifyDate">2018-05-14 14:40:09.302</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32727</identifier><datestamp>2018-05-14T18:46:06Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:18:44Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:18:44Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1960-09-02</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32727</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v30n28_1960-09-02</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1960 September 2nd</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n28_1960-09-02.pdf.txt</field>
+<field name="originalName">MW_v30n28_1960-09-02.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32727/3/MW_v30n28_1960-09-02.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n28_1960-09-02.txt.txt</field>
+<field name="originalName">MW_v30n28_1960-09-02.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">161009</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32727/5/MW_v30n28_1960-09-02.txt.txt</field>
+<field name="checksum">3d4daf35e82df79a718bde2647f0fbbf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n28_1960-09-02.pdf.jpg</field>
+<field name="originalName">MW_v30n28_1960-09-02.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">22471</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32727/4/MW_v30n28_1960-09-02.pdf.jpg</field>
+<field name="checksum">1b64bcac03136a48e3f002648aa4fd36</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n28_1960-09-02.pdf</field>
+<field name="originalName">MW_v30n28_1960-09-02.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32694269</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32727/1/MW_v30n28_1960-09-02.pdf</field>
+<field name="checksum">3a9a93cc205ba71163fb02f5a974ffe1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n28_1960-09-02.txt</field>
+<field name="originalName">MW_v30n28_1960-09-02.txt</field>
+<field name="format">text/plain</field>
+<field name="size">161018</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32727/2/MW_v30n28_1960-09-02.txt</field>
+<field name="checksum">346a239f614b3f84b9c5862c4fba941c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32727</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32727</field>
+<field name="lastModifyDate">2018-05-14 13:46:06.724</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32640</identifier><datestamp>2018-05-14T19:21:41Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-09T16:16:26Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-09T16:16:26Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1959-10-21</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32640</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v29n25_1959-10-21</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1959 October 21st</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n25_1959-10-21.txt</field>
+<field name="originalName">MW_v29n25_1959-10-21.txt</field>
+<field name="format">text/plain</field>
+<field name="size">207420</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32640/1/MW_v29n25_1959-10-21.txt</field>
+<field name="checksum">888fa0b6ee8797b0c2bdd030e17bf453</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v29n25_1959-10-21.pdf</field>
+<field name="originalName">MW_v29n25_1959-10-21.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">28624495</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32640/2/MW_v29n25_1959-10-21.pdf</field>
+<field name="checksum">15462bc38899ddad1e8f3e192368e7c8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n25_1959-10-21.txt.txt</field>
+<field name="originalName">MW_v29n25_1959-10-21.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">207415</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32640/3/MW_v29n25_1959-10-21.txt.txt</field>
+<field name="checksum">4bfb36cc487a226200de71bb678bc13f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v29n25_1959-10-21.pdf.txt</field>
+<field name="originalName">MW_v29n25_1959-10-21.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32640/4/MW_v29n25_1959-10-21.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n25_1959-10-21.pdf.jpg</field>
+<field name="originalName">MW_v29n25_1959-10-21.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26355</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32640/5/MW_v29n25_1959-10-21.pdf.jpg</field>
+<field name="checksum">400bcac5b9107c5d8b9a06102dff653a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32640</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32640</field>
+<field name="lastModifyDate">2018-05-14 14:21:41.041</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32394</identifier><datestamp>2018-05-14T19:40:08Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:20:56Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:20:56Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1955-06-03</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32394</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v23n97_1955-06-03</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1955 June 3rd</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n97_1955-06-03.pdf</field>
+<field name="originalName">MW_v23n97_1955-06-03.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">45697129</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32394/1/MW_v23n97_1955-06-03.pdf</field>
+<field name="checksum">4bdc140f0b863a9714b62ce80b9cd62d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n97_1955-06-03.txt</field>
+<field name="originalName">MW_v23n97_1955-06-03.txt</field>
+<field name="format">text/plain</field>
+<field name="size">69000</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32394/2/MW_v23n97_1955-06-03.txt</field>
+<field name="checksum">0a307da517c69c7fa0ba59a0b77a4139</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n97_1955-06-03.pdf.txt</field>
+<field name="originalName">MW_v23n97_1955-06-03.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32394/3/MW_v23n97_1955-06-03.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n97_1955-06-03.txt.txt</field>
+<field name="originalName">MW_v23n97_1955-06-03.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">68996</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32394/5/MW_v23n97_1955-06-03.txt.txt</field>
+<field name="checksum">53134e9652277cd1352eabda35f63d30</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n97_1955-06-03.pdf.jpg</field>
+<field name="originalName">MW_v23n97_1955-06-03.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26721</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32394/4/MW_v23n97_1955-06-03.pdf.jpg</field>
+<field name="checksum">919ba71754a4f7db5319c977f547efef</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32394</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32394</field>
+<field name="lastModifyDate">2018-05-14 14:40:08.959</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32109</identifier><datestamp>2018-05-14T19:40:04Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:58:39Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:58:39Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1956-05-22</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32109</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v24n95_1956-05-22</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1956 May 22nd</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n95_1956-05-22.pdf</field>
+<field name="originalName">MW_v24n95_1956-05-22.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">14269529</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32109/1/MW_v24n95_1956-05-22.pdf</field>
+<field name="checksum">9251a7d5b8c689e7c6eb67f2bdbcbfe3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v24n95_1956-05-22.txt</field>
+<field name="originalName">MW_v24n95_1956-05-22.txt</field>
+<field name="format">text/plain</field>
+<field name="size">188230</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32109/2/MW_v24n95_1956-05-22.txt</field>
+<field name="checksum">e608eddf1cc69a30cc24581de1bef741</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n95_1956-05-22.pdf.txt</field>
+<field name="originalName">MW_v24n95_1956-05-22.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32109/3/MW_v24n95_1956-05-22.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v24n95_1956-05-22.txt.txt</field>
+<field name="originalName">MW_v24n95_1956-05-22.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">188227</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32109/5/MW_v24n95_1956-05-22.txt.txt</field>
+<field name="checksum">89c39db520389f5853173c000097af4c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n95_1956-05-22.pdf.jpg</field>
+<field name="originalName">MW_v24n95_1956-05-22.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">19293</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32109/4/MW_v24n95_1956-05-22.pdf.jpg</field>
+<field name="checksum">f44471dcd3cd22be78add37523a1b7e0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32109</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32109</field>
+<field name="lastModifyDate">2018-05-14 14:40:04.606</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32732</identifier><datestamp>2018-05-14T18:46:07Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:18:45Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:18:45Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1960-09-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32732</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v30n15_1960-09-17</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1960 September 17th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n15_1960-09-17.txt.txt</field>
+<field name="originalName">MW_v30n15_1960-09-17.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">98650</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32732/3/MW_v30n15_1960-09-17.txt.txt</field>
+<field name="checksum">40fe1c0bc225df7755f1327a4b9bc448</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n15_1960-09-17.pdf.txt</field>
+<field name="originalName">MW_v30n15_1960-09-17.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32732/4/MW_v30n15_1960-09-17.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n15_1960-09-17.pdf.jpg</field>
+<field name="originalName">MW_v30n15_1960-09-17.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">22785</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32732/5/MW_v30n15_1960-09-17.pdf.jpg</field>
+<field name="checksum">e25e3f5e7ab8572b0a7f09f563fb2445</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n15_1960-09-17.txt</field>
+<field name="originalName">MW_v30n15_1960-09-17.txt</field>
+<field name="format">text/plain</field>
+<field name="size">98638</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32732/1/MW_v30n15_1960-09-17.txt</field>
+<field name="checksum">44d80cef099884ad42ecbcf54481cc03</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n15_1960-09-17.pdf</field>
+<field name="originalName">MW_v30n15_1960-09-17.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">45673098</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32732/2/MW_v30n15_1960-09-17.pdf</field>
+<field name="checksum">a462b4aefa6bfc067b51e276da18b43a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32732</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32732</field>
+<field name="lastModifyDate">2018-05-14 13:46:07.127</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32688</identifier><datestamp>2018-05-14T18:46:06Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:18:41Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:18:41Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1960-04-13</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32688</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v29n74_1960-04-13</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1960 April 13th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n74_1960-04-13.txt</field>
+<field name="originalName">MW_v29n74_1960-04-13.txt</field>
+<field name="format">text/plain</field>
+<field name="size">185410</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32688/1/MW_v29n74_1960-04-13.txt</field>
+<field name="checksum">382c5e6dab8f829edcd17c1314f92868</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v29n74_1960-04-13.pdf</field>
+<field name="originalName">MW_v29n74_1960-04-13.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">35503774</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32688/2/MW_v29n74_1960-04-13.pdf</field>
+<field name="checksum">c1e5eace4ab7081ef16a4229ecfa41d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n74_1960-04-13.txt.txt</field>
+<field name="originalName">MW_v29n74_1960-04-13.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">185405</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32688/3/MW_v29n74_1960-04-13.txt.txt</field>
+<field name="checksum">45f9b727f2a60c813d8dc9480b5a6010</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v29n74_1960-04-13.pdf.txt</field>
+<field name="originalName">MW_v29n74_1960-04-13.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32688/4/MW_v29n74_1960-04-13.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n74_1960-04-13.pdf.jpg</field>
+<field name="originalName">MW_v29n74_1960-04-13.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">23485</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32688/5/MW_v29n74_1960-04-13.pdf.jpg</field>
+<field name="checksum">982022a74f74dac66fbe76b19c85ee7f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32688</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32688</field>
+<field name="lastModifyDate">2018-05-14 13:46:06.957</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32766</identifier><datestamp>2018-05-14T18:46:08Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:21:05Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:21:05Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1961-08-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32766</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v30n10_1961-08-19</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1961 August 19th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n10_1961-08-19.pdf</field>
+<field name="originalName">MW_v30n10_1961-08-19.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">35961051</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32766/1/MW_v30n10_1961-08-19.pdf</field>
+<field name="checksum">8ef9cdbf89e95c3e5a24996cd721b8da</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n10_1961-08-19.txt</field>
+<field name="originalName">MW_v30n10_1961-08-19.txt</field>
+<field name="format">text/plain</field>
+<field name="size">61894</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32766/2/MW_v30n10_1961-08-19.txt</field>
+<field name="checksum">e0dbf719cb601237d57fe6bc46c294db</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n10_1961-08-19.pdf.txt</field>
+<field name="originalName">MW_v30n10_1961-08-19.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32766/3/MW_v30n10_1961-08-19.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n10_1961-08-19.txt.txt</field>
+<field name="originalName">MW_v30n10_1961-08-19.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">61896</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32766/5/MW_v30n10_1961-08-19.txt.txt</field>
+<field name="checksum">aa203cc3aadb77cbc9b60dbbf20e00ff</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n10_1961-08-19.pdf.jpg</field>
+<field name="originalName">MW_v30n10_1961-08-19.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">20856</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32766/4/MW_v30n10_1961-08-19.pdf.jpg</field>
+<field name="checksum">15bab42f46435f6e9dc3d59858c50395</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32766</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32766</field>
+<field name="lastModifyDate">2018-05-14 13:46:08.135</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32067</identifier><datestamp>2018-05-14T19:40:04Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:58:35Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:58:35Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1956-06-12</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32067</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v24n101_1956-06-12</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1956 June 12th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n101_1956-06-12.pdf</field>
+<field name="originalName">MW_v24n101_1956-06-12.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">13875587</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32067/1/MW_v24n101_1956-06-12.pdf</field>
+<field name="checksum">4c53d49628155e63251e30314eae187e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v24n101_1956-06-12.txt</field>
+<field name="originalName">MW_v24n101_1956-06-12.txt</field>
+<field name="format">text/plain</field>
+<field name="size">78706</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32067/2/MW_v24n101_1956-06-12.txt</field>
+<field name="checksum">1ffbe26f455df230bea197e1e9f9c89a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n101_1956-06-12.pdf.txt</field>
+<field name="originalName">MW_v24n101_1956-06-12.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32067/3/MW_v24n101_1956-06-12.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v24n101_1956-06-12.txt.txt</field>
+<field name="originalName">MW_v24n101_1956-06-12.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">78699</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32067/5/MW_v24n101_1956-06-12.txt.txt</field>
+<field name="checksum">531d16072f18b3f4159dee2450e7ace9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n101_1956-06-12.pdf.jpg</field>
+<field name="originalName">MW_v24n101_1956-06-12.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">20075</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32067/4/MW_v24n101_1956-06-12.pdf.jpg</field>
+<field name="checksum">dce69f8258130af1a95e439e29a6017e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32067</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32067</field>
+<field name="lastModifyDate">2018-05-14 14:40:04.774</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31623</identifier><datestamp>2018-05-14T18:57:33Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:22Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:22Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-01-03</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31623</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v18n55_1950-01-03</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 January 3rd</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n55_1950-01-03.pdf</field>
+<field name="originalName">MW_v18n55_1950-01-03.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">23911363</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31623/1/MW_v18n55_1950-01-03.pdf</field>
+<field name="checksum">656815ebca2a6bd9e34be3220c15d740</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n55_1950-01-03.txt</field>
+<field name="originalName">MW_v18n55_1950-01-03.txt</field>
+<field name="format">text/plain</field>
+<field name="size">377580</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31623/2/MW_v18n55_1950-01-03.txt</field>
+<field name="checksum">d8224008fbe4141feada1e23bcd19ba4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n55_1950-01-03.pdf.txt</field>
+<field name="originalName">MW_v18n55_1950-01-03.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31623/3/MW_v18n55_1950-01-03.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n55_1950-01-03.txt.txt</field>
+<field name="originalName">MW_v18n55_1950-01-03.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">377573</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31623/5/MW_v18n55_1950-01-03.txt.txt</field>
+<field name="checksum">b5a0034de0bd2fbf2bbb7a9814fd5fab</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n55_1950-01-03.pdf.jpg</field>
+<field name="originalName">MW_v18n55_1950-01-03.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">19529</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31623/4/MW_v18n55_1950-01-03.pdf.jpg</field>
+<field name="checksum">dbb00281ee8508c735c0b93919783ab6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31623</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31623</field>
+<field name="lastModifyDate">2018-05-14 13:57:33.871</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31696</identifier><datestamp>2018-05-14T18:57:33Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:28Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:28Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-10-13</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31696</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v19n33_1950-10-13</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 October 13th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n33_1950-10-13.pdf.txt</field>
+<field name="originalName">MW_v19n33_1950-10-13.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31696/3/MW_v19n33_1950-10-13.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n33_1950-10-13.txt.txt</field>
+<field name="originalName">MW_v19n33_1950-10-13.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">135504</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31696/5/MW_v19n33_1950-10-13.txt.txt</field>
+<field name="checksum">94e7d558222c7c5980f1afca05876c0b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n33_1950-10-13.pdf.jpg</field>
+<field name="originalName">MW_v19n33_1950-10-13.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">20351</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31696/4/MW_v19n33_1950-10-13.pdf.jpg</field>
+<field name="checksum">d7b2756ec887c93aac433b9bda5c6e85</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n33_1950-10-13.pdf</field>
+<field name="originalName">MW_v19n33_1950-10-13.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">19264018</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31696/1/MW_v19n33_1950-10-13.pdf</field>
+<field name="checksum">33ba9555c29e8301ac5a3eea6afb9e80</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n33_1950-10-13.txt</field>
+<field name="originalName">MW_v19n33_1950-10-13.txt</field>
+<field name="format">text/plain</field>
+<field name="size">135506</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31696/2/MW_v19n33_1950-10-13.txt</field>
+<field name="checksum">c5a8b8c5672770d4daf09b59b77861c1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31696</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31696</field>
+<field name="lastModifyDate">2018-05-14 13:57:33.299</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32239</identifier><datestamp>2018-05-14T19:40:06Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-02T15:14:12Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-02T15:14:12Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1953-11-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32239</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v22n28_1953-11-17</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1953 November 17th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n28_1953-11-17.pdf</field>
+<field name="originalName">MW_v22n28_1953-11-17.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">40332112</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32239/2/MW_v22n28_1953-11-17.pdf</field>
+<field name="checksum">611458a916ba491864e40a30e9c8196b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v22n28_1953-11-17.txt</field>
+<field name="originalName">MW_v22n28_1953-11-17.txt</field>
+<field name="format">text/plain</field>
+<field name="size">141318</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32239/1/MW_v22n28_1953-11-17.txt</field>
+<field name="checksum">05bcd0db500f9958a4a69503ecd3ad99</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n28_1953-11-17.pdf.txt</field>
+<field name="originalName">MW_v22n28_1953-11-17.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32239/3/MW_v22n28_1953-11-17.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v22n28_1953-11-17.txt.txt</field>
+<field name="originalName">MW_v22n28_1953-11-17.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">141275</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32239/5/MW_v22n28_1953-11-17.txt.txt</field>
+<field name="checksum">3529ec0415c75a65ce4db4f170be006f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n28_1953-11-17.pdf.jpg</field>
+<field name="originalName">MW_v22n28_1953-11-17.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26940</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32239/4/MW_v22n28_1953-11-17.pdf.jpg</field>
+<field name="checksum">dc6a97330dd6800617911fc352ec09ec</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32239</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32239</field>
+<field name="lastModifyDate">2018-05-14 14:40:06.584</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32148</identifier><datestamp>2018-05-14T19:40:03Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:58:43Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:58:43Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1956-12-26</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32148</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v25n45_1956-12-26</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1956 December 26th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v25n45_1956-12-26.txt</field>
+<field name="originalName">MW_v25n45_1956-12-26.txt</field>
+<field name="format">text/plain</field>
+<field name="size">92552</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32148/1/MW_v25n45_1956-12-26.txt</field>
+<field name="checksum">ca16f79317fde285cba143759ce09256</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v25n45_1956-12-26.pdf</field>
+<field name="originalName">MW_v25n45_1956-12-26.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">13640881</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32148/2/MW_v25n45_1956-12-26.pdf</field>
+<field name="checksum">1d0690fe7e24617f645805aaab414e62</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v25n45_1956-12-26.txt.txt</field>
+<field name="originalName">MW_v25n45_1956-12-26.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">92541</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32148/3/MW_v25n45_1956-12-26.txt.txt</field>
+<field name="checksum">6b32ee86e02dcf0ce03948b3575da5d9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v25n45_1956-12-26.pdf.txt</field>
+<field name="originalName">MW_v25n45_1956-12-26.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32148/4/MW_v25n45_1956-12-26.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v25n45_1956-12-26.pdf.jpg</field>
+<field name="originalName">MW_v25n45_1956-12-26.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">20765</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32148/5/MW_v25n45_1956-12-26.pdf.jpg</field>
+<field name="checksum">4af875d8000d25c3cfa3ea02beeadfed</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32148</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32148</field>
+<field name="lastModifyDate">2018-05-14 14:40:03.457</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32104</identifier><datestamp>2018-05-14T19:40:04Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:58:39Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:58:39Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1956-04-24</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32104</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v24n88_1956-04-24</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1956 April 24th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n88_1956-04-24.pdf</field>
+<field name="originalName">MW_v24n88_1956-04-24.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">15111439</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32104/1/MW_v24n88_1956-04-24.pdf</field>
+<field name="checksum">9db1456a4a1fa955fe16aa2664e3050d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v24n88_1956-04-24.txt</field>
+<field name="originalName">MW_v24n88_1956-04-24.txt</field>
+<field name="format">text/plain</field>
+<field name="size">97388</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32104/2/MW_v24n88_1956-04-24.txt</field>
+<field name="checksum">c5b3ebec0eaa199f3b0e237b9bee5aaf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n88_1956-04-24.pdf.txt</field>
+<field name="originalName">MW_v24n88_1956-04-24.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32104/3/MW_v24n88_1956-04-24.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v24n88_1956-04-24.txt.txt</field>
+<field name="originalName">MW_v24n88_1956-04-24.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">97380</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32104/5/MW_v24n88_1956-04-24.txt.txt</field>
+<field name="checksum">518b8bd72564cc76463cb0071dc1d55a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n88_1956-04-24.pdf.jpg</field>
+<field name="originalName">MW_v24n88_1956-04-24.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">20156</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32104/4/MW_v24n88_1956-04-24.pdf.jpg</field>
+<field name="checksum">184ffc0bf11d7ea87c87d6b11e000750</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32104</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32104</field>
+<field name="lastModifyDate">2018-05-14 14:40:04.565</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32249</identifier><datestamp>2018-05-14T19:40:06Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-02T15:14:13Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-02T15:14:13Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1953-12-25</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32249</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v22n38_1953-12-25</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1953 December 25th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n38_1953-12-25.pdf.txt</field>
+<field name="originalName">MW_v22n38_1953-12-25.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32249/3/MW_v22n38_1953-12-25.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v22n38_1953-12-25.txt.txt</field>
+<field name="originalName">MW_v22n38_1953-12-25.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">105888</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32249/5/MW_v22n38_1953-12-25.txt.txt</field>
+<field name="checksum">9de466507f3a1c865420b8743fba0a3a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n38_1953-12-25.pdf.jpg</field>
+<field name="originalName">MW_v22n38_1953-12-25.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">28483</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32249/4/MW_v22n38_1953-12-25.pdf.jpg</field>
+<field name="checksum">62282f6b9071093be0cf566385433fbd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n38_1953-12-25.pdf</field>
+<field name="originalName">MW_v22n38_1953-12-25.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">35783410</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32249/1/MW_v22n38_1953-12-25.pdf</field>
+<field name="checksum">d2924ebc7fe8508497a1cff3dd0f243b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v22n38_1953-12-25.txt</field>
+<field name="originalName">MW_v22n38_1953-12-25.txt</field>
+<field name="format">text/plain</field>
+<field name="size">105886</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32249/2/MW_v22n38_1953-12-25.txt</field>
+<field name="checksum">398a175cfb9c1b6714c7c9606ac23031</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32249</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32249</field>
+<field name="lastModifyDate">2018-05-14 14:40:06.771</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33215</identifier><datestamp>2018-05-14T19:38:13Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-23T14:12:35Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-23T14:12:35Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1957-11-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33215</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v27n38_1957-11-30</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1957 November 30th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n38_1957-11-30.pdf</field>
+<field name="originalName">MW_v27n38_1957-11-30.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32948644</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33215/1/MW_v27n38_1957-11-30.pdf</field>
+<field name="checksum">e813507f01ab07164cbf49ad4e7c1b4e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v27n38_1957-11-30.txt</field>
+<field name="originalName">MW_v27n38_1957-11-30.txt</field>
+<field name="format">text/plain</field>
+<field name="size">96504</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33215/2/MW_v27n38_1957-11-30.txt</field>
+<field name="checksum">cbc39a260147909f7fa51d9dbc52145e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n38_1957-11-30.pdf.txt</field>
+<field name="originalName">MW_v27n38_1957-11-30.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33215/3/MW_v27n38_1957-11-30.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v27n38_1957-11-30.txt.txt</field>
+<field name="originalName">MW_v27n38_1957-11-30.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">96495</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33215/5/MW_v27n38_1957-11-30.txt.txt</field>
+<field name="checksum">5ae44da048c1a0748590121da5a85d2e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n38_1957-11-30.pdf.jpg</field>
+<field name="originalName">MW_v27n38_1957-11-30.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27637</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33215/4/MW_v27n38_1957-11-30.pdf.jpg</field>
+<field name="checksum">c4ead6f8c36f74373aa3dcb193b759f5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33215</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33215</field>
+<field name="lastModifyDate">2018-05-14 14:38:13.77</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32391</identifier><datestamp>2018-05-14T19:40:09Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:20:55Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:20:55Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1955-05-24</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32391</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v23n94_1955-05-24</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1955 May 24th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n94_1955-05-24.pdf</field>
+<field name="originalName">MW_v23n94_1955-05-24.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">40344574</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32391/1/MW_v23n94_1955-05-24.pdf</field>
+<field name="checksum">94e39b5371789bff7adba55be557bdc7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n94_1955-05-24.txt</field>
+<field name="originalName">MW_v23n94_1955-05-24.txt</field>
+<field name="format">text/plain</field>
+<field name="size">59492</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32391/2/MW_v23n94_1955-05-24.txt</field>
+<field name="checksum">e932167a85468446bf760b63d39b6ef0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n94_1955-05-24.pdf.txt</field>
+<field name="originalName">MW_v23n94_1955-05-24.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32391/3/MW_v23n94_1955-05-24.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n94_1955-05-24.txt.txt</field>
+<field name="originalName">MW_v23n94_1955-05-24.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">59495</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32391/5/MW_v23n94_1955-05-24.txt.txt</field>
+<field name="checksum">dfced534a79dd9b7216329d9ea5d8bd9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n94_1955-05-24.pdf.jpg</field>
+<field name="originalName">MW_v23n94_1955-05-24.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26845</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32391/4/MW_v23n94_1955-05-24.pdf.jpg</field>
+<field name="checksum">98021bdd7b5f4007ffc7f7b761ff6ac2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32391</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32391</field>
+<field name="lastModifyDate">2018-05-14 14:40:09.86</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32569</identifier><datestamp>2018-05-14T19:21:40Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-09T16:16:18Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-09T16:16:18Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1959-02-07</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32569</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v28n65_1959-02-07</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1959 February 7th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n65_1959-02-07.txt</field>
+<field name="originalName">MW_v28n65_1959-02-07.txt</field>
+<field name="format">text/plain</field>
+<field name="size">110132</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32569/1/MW_v28n65_1959-02-07.txt</field>
+<field name="checksum">804015558976e3552e0e4bc41c27f671</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n65_1959-02-07.pdf</field>
+<field name="originalName">MW_v28n65_1959-02-07.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">37537611</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32569/2/MW_v28n65_1959-02-07.pdf</field>
+<field name="checksum">ae63a0780c1abe3b720e95abcbe06cd1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n65_1959-02-07.txt.txt</field>
+<field name="originalName">MW_v28n65_1959-02-07.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">110134</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32569/3/MW_v28n65_1959-02-07.txt.txt</field>
+<field name="checksum">da632d6fc47036b96b6f05207802c5ad</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n65_1959-02-07.pdf.txt</field>
+<field name="originalName">MW_v28n65_1959-02-07.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32569/4/MW_v28n65_1959-02-07.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n65_1959-02-07.pdf.jpg</field>
+<field name="originalName">MW_v28n65_1959-02-07.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27158</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32569/5/MW_v28n65_1959-02-07.pdf.jpg</field>
+<field name="checksum">a46efb6ee7a15ebe02b600960422fd38</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32569</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32569</field>
+<field name="lastModifyDate">2018-05-14 14:21:40.719</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32901</identifier><datestamp>2018-05-14T18:46:11Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:23:46Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:23:46Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1964-07-11</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32901</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v33n5_1964-07-11</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1964 July 11th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v33n5_1964-07-11.pdf</field>
+<field name="originalName">MW_v33n5_1964-07-11.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32121814</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32901/1/MW_v33n5_1964-07-11.pdf</field>
+<field name="checksum">7157bb8e611ea139b3ad00f976b8ef60</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v33n5_1964-07-11.txt</field>
+<field name="originalName">MW_v33n5_1964-07-11.txt</field>
+<field name="format">text/plain</field>
+<field name="size">66364</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32901/2/MW_v33n5_1964-07-11.txt</field>
+<field name="checksum">344a6262b0adacf15d67b50368f404aa</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v33n5_1964-07-11.pdf.txt</field>
+<field name="originalName">MW_v33n5_1964-07-11.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32901/3/MW_v33n5_1964-07-11.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v33n5_1964-07-11.txt.txt</field>
+<field name="originalName">MW_v33n5_1964-07-11.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">66353</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32901/4/MW_v33n5_1964-07-11.txt.txt</field>
+<field name="checksum">349dbd3601fbae81e9f1c7841fddab6b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32901</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32901</field>
+<field name="lastModifyDate">2018-05-14 13:46:11.33</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31877</identifier><datestamp>2018-05-14T19:35:36Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-15T22:40:51Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-15T22:40:51Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1951-01-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31877</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v19n61_1951-01-19</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1951 January 19th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n61_1951-01-19.pdf.txt</field>
+<field name="originalName">MW_v19n61_1951-01-19.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31877/3/MW_v19n61_1951-01-19.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n61_1951-01-19.txt.txt</field>
+<field name="originalName">MW_v19n61_1951-01-19.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">50789</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31877/5/MW_v19n61_1951-01-19.txt.txt</field>
+<field name="checksum">6e180770abab64de07ee6585b477db35</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n61_1951-01-19.pdf.jpg</field>
+<field name="originalName">MW_v19n61_1951-01-19.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27082</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31877/4/MW_v19n61_1951-01-19.pdf.jpg</field>
+<field name="checksum">f1be4ddf83cc0d17bc83849ae982f7ce</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n61_1951-01-19.pdf</field>
+<field name="originalName">MW_v19n61_1951-01-19.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">37301954</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31877/2/MW_v19n61_1951-01-19.pdf</field>
+<field name="checksum">145c9b8c1329bedf9f3af6eeddfedc41</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n61_1951-01-19.txt</field>
+<field name="originalName">MW_v19n61_1951-01-19.txt</field>
+<field name="format">text/plain</field>
+<field name="size">50794</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31877/1/MW_v19n61_1951-01-19.txt</field>
+<field name="checksum">24321d020148f64b745574bd936c5d82</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31877</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31877</field>
+<field name="lastModifyDate">2018-05-14 14:35:36.551</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32246</identifier><datestamp>2018-05-14T19:40:07Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-02T15:14:13Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-02T15:14:13Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1953-12-11</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32246</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v22n35_1953-12-11</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1953 December 11th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n35_1953-12-11.pdf.txt</field>
+<field name="originalName">MW_v22n35_1953-12-11.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32246/2/MW_v22n35_1953-12-11.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n35_1953-12-11.pdf.jpg</field>
+<field name="originalName">MW_v22n35_1953-12-11.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26388</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32246/3/MW_v22n35_1953-12-11.pdf.jpg</field>
+<field name="checksum">d490429979af164393bc9abcaac7f862</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n35_1953-12-11.pdf</field>
+<field name="originalName">MW_v22n35_1953-12-11.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">40987358</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32246/1/MW_v22n35_1953-12-11.pdf</field>
+<field name="checksum">df6c88461154b23e17c68d3c95ae3845</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32246</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32246</field>
+<field name="lastModifyDate">2018-05-14 14:40:07.221</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32407</identifier><datestamp>2018-05-14T19:40:09Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:20:57Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:20:57Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1955-07-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32407</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v24n10_1955-07-19</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1955 July 19th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n10_1955-07-19.pdf</field>
+<field name="originalName">MW_v24n10_1955-07-19.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">49673152</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32407/1/MW_v24n10_1955-07-19.pdf</field>
+<field name="checksum">f2712d692ed263d403ddd64976aca417</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v24n10_1955-07-19.txt</field>
+<field name="originalName">MW_v24n10_1955-07-19.txt</field>
+<field name="format">text/plain</field>
+<field name="size">84330</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32407/2/MW_v24n10_1955-07-19.txt</field>
+<field name="checksum">f368d8bdcc5981d9df123177b4f1b54e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n10_1955-07-19.pdf.txt</field>
+<field name="originalName">MW_v24n10_1955-07-19.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32407/3/MW_v24n10_1955-07-19.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v24n10_1955-07-19.txt.txt</field>
+<field name="originalName">MW_v24n10_1955-07-19.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">84326</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32407/5/MW_v24n10_1955-07-19.txt.txt</field>
+<field name="checksum">e3ea903e6b7043b5a37747d9b3b3a2c1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n10_1955-07-19.pdf.jpg</field>
+<field name="originalName">MW_v24n10_1955-07-19.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27963</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32407/4/MW_v24n10_1955-07-19.pdf.jpg</field>
+<field name="checksum">8fe41564c2c2114a4b87a5877aa7a52d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32407</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32407</field>
+<field name="lastModifyDate">2018-05-14 14:40:09.821</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32675</identifier><datestamp>2018-05-14T18:46:06Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:18:39Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:18:39Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1960-02-27</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32675</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v29n61_1960-02-27</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1960 February 27th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n61_1960-02-27.txt</field>
+<field name="originalName">MW_v29n61_1960-02-27.txt</field>
+<field name="format">text/plain</field>
+<field name="size">108412</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32675/1/MW_v29n61_1960-02-27.txt</field>
+<field name="checksum">ba980a03b1c3e71e02ae3080654fe56e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v29n61_1960-02-27.pdf</field>
+<field name="originalName">MW_v29n61_1960-02-27.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">43648208</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32675/2/MW_v29n61_1960-02-27.pdf</field>
+<field name="checksum">8a76f4704d6a67431b9cd1f980d02888</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n61_1960-02-27.txt.txt</field>
+<field name="originalName">MW_v29n61_1960-02-27.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">108428</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32675/3/MW_v29n61_1960-02-27.txt.txt</field>
+<field name="checksum">37b2c3a76d37ba25f1c88e94a26b23c8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v29n61_1960-02-27.pdf.txt</field>
+<field name="originalName">MW_v29n61_1960-02-27.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32675/4/MW_v29n61_1960-02-27.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v29n61_1960-02-27.pdf.jpg</field>
+<field name="originalName">MW_v29n61_1960-02-27.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21400</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32675/5/MW_v29n61_1960-02-27.pdf.jpg</field>
+<field name="checksum">68a064f66e52b8cee3d0842cbe5da43c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32675</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32675</field>
+<field name="lastModifyDate">2018-05-14 13:46:06.944</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32865</identifier><datestamp>2018-05-14T18:46:04Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:23:43Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:23:43Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1964-03-28</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32865</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v32n42_1964-03-28</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1964 March 28th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v32n42_1964-03-28.txt</field>
+<field name="originalName">MW_v32n42_1964-03-28.txt</field>
+<field name="format">text/plain</field>
+<field name="size">86792</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32865/1/MW_v32n42_1964-03-28.txt</field>
+<field name="checksum">689ab3b63f20e63f529cd58a5e7e99e0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v32n42_1964-03-28.pdf</field>
+<field name="originalName">MW_v32n42_1964-03-28.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32122813</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32865/2/MW_v32n42_1964-03-28.pdf</field>
+<field name="checksum">b7267ae7c6db4bb888a56b2c0ba4d625</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v32n42_1964-03-28.txt.txt</field>
+<field name="originalName">MW_v32n42_1964-03-28.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">86782</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32865/3/MW_v32n42_1964-03-28.txt.txt</field>
+<field name="checksum">b1be37340d85dbb2c4e9ca926beab48f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v32n42_1964-03-28.pdf.txt</field>
+<field name="originalName">MW_v32n42_1964-03-28.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32865/4/MW_v32n42_1964-03-28.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v32n42_1964-03-28.pdf.jpg</field>
+<field name="originalName">MW_v32n42_1964-03-28.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">20768</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32865/5/MW_v32n42_1964-03-28.pdf.jpg</field>
+<field name="checksum">439f2d1038e1a9fca305b794ce64f08d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32865</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32865</field>
+<field name="lastModifyDate">2018-05-14 13:46:04.467</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32895</identifier><datestamp>2018-05-14T18:46:13Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:23:45Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:23:45Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1964-12-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32895</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v33n28_1964-12-19</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1964 December 19th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v33n28_1964-12-19.txt</field>
+<field name="originalName">MW_v33n28_1964-12-19.txt</field>
+<field name="format">text/plain</field>
+<field name="size">71326</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32895/1/MW_v33n28_1964-12-19.txt</field>
+<field name="checksum">78086739ead3ed95888db4972f63052f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v33n28_1964-12-19.pdf</field>
+<field name="originalName">MW_v33n28_1964-12-19.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">31474825</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32895/2/MW_v33n28_1964-12-19.pdf</field>
+<field name="checksum">4220b0b685eb63f380d9c7d5651aaa78</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v33n28_1964-12-19.txt.txt</field>
+<field name="originalName">MW_v33n28_1964-12-19.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">71330</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32895/3/MW_v33n28_1964-12-19.txt.txt</field>
+<field name="checksum">109190c0afaa1cf06fe36f61f2679167</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v33n28_1964-12-19.pdf.txt</field>
+<field name="originalName">MW_v33n28_1964-12-19.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32895/4/MW_v33n28_1964-12-19.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32895</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32895</field>
+<field name="lastModifyDate">2018-05-14 13:46:13.779</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32375</identifier><datestamp>2018-05-14T19:40:08Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:20:53Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:20:53Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1955-03-29</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32375</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v23n78_1955-03-29</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1955 March 29th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n78_1955-03-29.pdf.txt</field>
+<field name="originalName">MW_v23n78_1955-03-29.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32375/3/MW_v23n78_1955-03-29.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n78_1955-03-29.txt.txt</field>
+<field name="originalName">MW_v23n78_1955-03-29.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">144396</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32375/5/MW_v23n78_1955-03-29.txt.txt</field>
+<field name="checksum">e29f8066f836d534712f7583adf208be</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n78_1955-03-29.pdf.jpg</field>
+<field name="originalName">MW_v23n78_1955-03-29.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26543</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32375/4/MW_v23n78_1955-03-29.pdf.jpg</field>
+<field name="checksum">cb42535e426e724d1d4a5c4d93bb83c0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n78_1955-03-29.pdf</field>
+<field name="originalName">MW_v23n78_1955-03-29.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">47102721</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32375/1/MW_v23n78_1955-03-29.pdf</field>
+<field name="checksum">9eb45042f4845fed81bf97f7edd44825</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n78_1955-03-29.txt</field>
+<field name="originalName">MW_v23n78_1955-03-29.txt</field>
+<field name="format">text/plain</field>
+<field name="size">144406</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32375/2/MW_v23n78_1955-03-29.txt</field>
+<field name="checksum">53ac898a44bb8d2b833ca8e8cf708e8f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32375</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32375</field>
+<field name="lastModifyDate">2018-05-14 14:40:08.278</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31969</identifier><datestamp>2018-05-14T19:36:51Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:54:25Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:54:25Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1952-06-10</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31969</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v20n100_1952-06-10</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1952 June 10th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n100_1952-06-10.pdf</field>
+<field name="originalName">MW_v20n100_1952-06-10.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">48476411</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31969/1/MW_v20n100_1952-06-10.pdf</field>
+<field name="checksum">b33d8d4a37885e92ef8bd6fd684c0e63</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n100_1952-06-10.txt</field>
+<field name="originalName">MW_v20n100_1952-06-10.txt</field>
+<field name="format">text/plain</field>
+<field name="size">110508</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31969/2/MW_v20n100_1952-06-10.txt</field>
+<field name="checksum">bccd41b718bf55a20a476b02b1dd6dad</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n100_1952-06-10.pdf.txt</field>
+<field name="originalName">MW_v20n100_1952-06-10.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31969/3/MW_v20n100_1952-06-10.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n100_1952-06-10.txt.txt</field>
+<field name="originalName">MW_v20n100_1952-06-10.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">110506</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31969/5/MW_v20n100_1952-06-10.txt.txt</field>
+<field name="checksum">5a2b38bba1428ee70d7fc54d23c8c9fe</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n100_1952-06-10.pdf.jpg</field>
+<field name="originalName">MW_v20n100_1952-06-10.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26641</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31969/4/MW_v20n100_1952-06-10.pdf.jpg</field>
+<field name="checksum">ebe534f90ddbb0ac355250d186cb4098</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31969</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31969</field>
+<field name="lastModifyDate">2018-05-14 14:36:51.958</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32194</identifier><datestamp>2018-05-14T19:40:07Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-02T15:14:05Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-02T15:14:05Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1953-02-10</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32194</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v21n50_1953-02-10</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1953 February 10th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n50_1953-02-10.pdf</field>
+<field name="originalName">MW_v21n50_1953-02-10.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">41520315</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32194/1/MW_v21n50_1953-02-10.pdf</field>
+<field name="checksum">43e679e37fec700e7f132c8d76c997b3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v21n50_1953-02-10.txt</field>
+<field name="originalName">MW_v21n50_1953-02-10.txt</field>
+<field name="format">text/plain</field>
+<field name="size">111312</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32194/2/MW_v21n50_1953-02-10.txt</field>
+<field name="checksum">e6fca478293bd183801afbf52697459b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n50_1953-02-10.pdf.txt</field>
+<field name="originalName">MW_v21n50_1953-02-10.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32194/3/MW_v21n50_1953-02-10.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v21n50_1953-02-10.txt.txt</field>
+<field name="originalName">MW_v21n50_1953-02-10.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">111312</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32194/5/MW_v21n50_1953-02-10.txt.txt</field>
+<field name="checksum">ba3d61f22063b25376e655a3191f07a0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n50_1953-02-10.pdf.jpg</field>
+<field name="originalName">MW_v21n50_1953-02-10.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27465</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32194/4/MW_v21n50_1953-02-10.pdf.jpg</field>
+<field name="checksum">551ad19d7dce316a35b358680916ec23</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32194</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32194</field>
+<field name="lastModifyDate">2018-05-14 14:40:07.595</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32535</identifier><datestamp>2018-05-14T19:25:36Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:22:11Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:22:11Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1958-11-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32535</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v28n43_1958-11-19</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1958 November 19th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n43_1958-11-19.txt</field>
+<field name="originalName">MW_v28n43_1958-11-19.txt</field>
+<field name="format">text/plain</field>
+<field name="size">163700</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32535/1/MW_v28n43_1958-11-19.txt</field>
+<field name="checksum">0e19c46b3962a103ec6185e3aeea063b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n43_1958-11-19.pdf</field>
+<field name="originalName">MW_v28n43_1958-11-19.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">24808516</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32535/2/MW_v28n43_1958-11-19.pdf</field>
+<field name="checksum">a8649db7a63fdeb1d60ee3cf5e6de37b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n43_1958-11-19.txt.txt</field>
+<field name="originalName">MW_v28n43_1958-11-19.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">163694</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32535/3/MW_v28n43_1958-11-19.txt.txt</field>
+<field name="checksum">8ae39bc386fc70125d7ac3e793f0dca3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n43_1958-11-19.pdf.txt</field>
+<field name="originalName">MW_v28n43_1958-11-19.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32535/4/MW_v28n43_1958-11-19.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n43_1958-11-19.pdf.jpg</field>
+<field name="originalName">MW_v28n43_1958-11-19.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26020</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32535/5/MW_v28n43_1958-11-19.pdf.jpg</field>
+<field name="checksum">37d3638e3346bf6daad53ef85d365f9d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32535</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32535</field>
+<field name="lastModifyDate">2018-05-14 14:25:36.357</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32754</identifier><datestamp>2018-05-14T18:46:04Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:18:47Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:18:47Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1960-12-07</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32754</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v30n38_1960-12-07</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1960 December 7th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n38_1960-12-07.txt</field>
+<field name="originalName">MW_v30n38_1960-12-07.txt</field>
+<field name="format">text/plain</field>
+<field name="size">101228</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32754/1/MW_v30n38_1960-12-07.txt</field>
+<field name="checksum">8a7e5391986b0616412313d03b6828b1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n38_1960-12-07.pdf</field>
+<field name="originalName">MW_v30n38_1960-12-07.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">33732283</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32754/2/MW_v30n38_1960-12-07.pdf</field>
+<field name="checksum">d9c1e4c20859a47c0718b9feb7fdcd0f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n38_1960-12-07.txt.txt</field>
+<field name="originalName">MW_v30n38_1960-12-07.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">101229</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32754/3/MW_v30n38_1960-12-07.txt.txt</field>
+<field name="checksum">bb226e822e8e54a39ea847053f102c21</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n38_1960-12-07.pdf.txt</field>
+<field name="originalName">MW_v30n38_1960-12-07.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32754/4/MW_v30n38_1960-12-07.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n38_1960-12-07.pdf.jpg</field>
+<field name="originalName">MW_v30n38_1960-12-07.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21852</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32754/5/MW_v30n38_1960-12-07.pdf.jpg</field>
+<field name="checksum">42316a039ad98fb1c984da3658caaf34</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32754</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32754</field>
+<field name="lastModifyDate">2018-05-14 13:46:04.479</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32397</identifier><datestamp>2018-05-14T19:40:08Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:20:56Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:20:56Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1955-06-14</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32397</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v23n100_1955-06-14</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1955 June 14th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n100_1955-06-14.pdf.txt</field>
+<field name="originalName">MW_v23n100_1955-06-14.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32397/3/MW_v23n100_1955-06-14.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n100_1955-06-14.txt.txt</field>
+<field name="originalName">MW_v23n100_1955-06-14.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">74813</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32397/5/MW_v23n100_1955-06-14.txt.txt</field>
+<field name="checksum">1d105f24938930037bc0fce9191520d6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n100_1955-06-14.pdf.jpg</field>
+<field name="originalName">MW_v23n100_1955-06-14.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">25645</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32397/4/MW_v23n100_1955-06-14.pdf.jpg</field>
+<field name="checksum">f25b80855e4217369dcb55955f875ea0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n100_1955-06-14.pdf</field>
+<field name="originalName">MW_v23n100_1955-06-14.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">47909562</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32397/1/MW_v23n100_1955-06-14.pdf</field>
+<field name="checksum">a3aefd45cc03c8bfe8e0300dc991a2b3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n100_1955-06-14.txt</field>
+<field name="originalName">MW_v23n100_1955-06-14.txt</field>
+<field name="format">text/plain</field>
+<field name="size">74810</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32397/2/MW_v23n100_1955-06-14.txt</field>
+<field name="checksum">7c0086c07b34d2c9c9c3ec6c6701e33a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32397</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32397</field>
+<field name="lastModifyDate">2018-05-14 14:40:08.09</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32212</identifier><datestamp>2018-05-14T19:40:05Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-02T15:14:08Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-02T15:14:08Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1953-04-28</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32212</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v21n72_1953-04-28</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1953 April 28th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n72_1953-04-28.pdf</field>
+<field name="originalName">MW_v21n72_1953-04-28.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">45185056</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32212/1/MW_v21n72_1953-04-28.pdf</field>
+<field name="checksum">a2b4c29fd9e6e91bf01032b69a4e59de</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v21n72_1953-04-28.txt</field>
+<field name="originalName">MW_v21n72_1953-04-28.txt</field>
+<field name="format">text/plain</field>
+<field name="size">130976</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32212/2/MW_v21n72_1953-04-28.txt</field>
+<field name="checksum">841815c4666830144116f5453ad144bf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n72_1953-04-28.pdf.txt</field>
+<field name="originalName">MW_v21n72_1953-04-28.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32212/3/MW_v21n72_1953-04-28.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v21n72_1953-04-28.txt.txt</field>
+<field name="originalName">MW_v21n72_1953-04-28.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">130983</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32212/5/MW_v21n72_1953-04-28.txt.txt</field>
+<field name="checksum">52252dba6542d8d34a8895895f32e05f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n72_1953-04-28.pdf.jpg</field>
+<field name="originalName">MW_v21n72_1953-04-28.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27278</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32212/4/MW_v21n72_1953-04-28.pdf.jpg</field>
+<field name="checksum">3bae8fce282e853734d10ba019d39f72</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32212</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32212</field>
+<field name="lastModifyDate">2018-05-14 14:40:05.38</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32588</identifier><datestamp>2018-05-14T19:21:42Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-09T16:16:21Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-09T16:16:21Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1959-04-15</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32588</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v28n84_1959-04-15</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1959 April 15th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n84_1959-04-15.txt</field>
+<field name="originalName">MW_v28n84_1959-04-15.txt</field>
+<field name="format">text/plain</field>
+<field name="size">126842</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32588/1/MW_v28n84_1959-04-15.txt</field>
+<field name="checksum">d4aef0523d59e4cd9df442d8134dedd5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n84_1959-04-15.pdf</field>
+<field name="originalName">MW_v28n84_1959-04-15.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">29841978</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32588/2/MW_v28n84_1959-04-15.pdf</field>
+<field name="checksum">7327a7649274fd61d24c393a9136665c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n84_1959-04-15.txt.txt</field>
+<field name="originalName">MW_v28n84_1959-04-15.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">126837</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32588/3/MW_v28n84_1959-04-15.txt.txt</field>
+<field name="checksum">3af06a1a49812bca57e71e91bb45a9e7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v28n84_1959-04-15.pdf.txt</field>
+<field name="originalName">MW_v28n84_1959-04-15.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32588/4/MW_v28n84_1959-04-15.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v28n84_1959-04-15.pdf.jpg</field>
+<field name="originalName">MW_v28n84_1959-04-15.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26755</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32588/5/MW_v28n84_1959-04-15.pdf.jpg</field>
+<field name="checksum">6b229da694d92887912fc86383afbb26</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32588</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32588</field>
+<field name="lastModifyDate">2018-05-14 14:21:42.748</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32012</identifier><datestamp>2018-05-14T19:36:51Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:54:33Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:54:33Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1952-04-15</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32012</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v20n84_1952-04-15</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1952 April 15th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n84_1952-04-15.pdf</field>
+<field name="originalName">MW_v20n84_1952-04-15.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">40914238</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32012/1/MW_v20n84_1952-04-15.pdf</field>
+<field name="checksum">29441aac0fad41cf337b4d05909ecb3a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n84_1952-04-15.txt</field>
+<field name="originalName">MW_v20n84_1952-04-15.txt</field>
+<field name="format">text/plain</field>
+<field name="size">68304</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32012/2/MW_v20n84_1952-04-15.txt</field>
+<field name="checksum">10096b619c9200758f9b3e4adfa76579</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n84_1952-04-15.pdf.txt</field>
+<field name="originalName">MW_v20n84_1952-04-15.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32012/3/MW_v20n84_1952-04-15.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n84_1952-04-15.txt.txt</field>
+<field name="originalName">MW_v20n84_1952-04-15.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">68302</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32012/5/MW_v20n84_1952-04-15.txt.txt</field>
+<field name="checksum">cee6b8eb5f33cd9820634b57457f1bd8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n84_1952-04-15.pdf.jpg</field>
+<field name="originalName">MW_v20n84_1952-04-15.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">25138</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32012/4/MW_v20n84_1952-04-15.pdf.jpg</field>
+<field name="checksum">ddde898efabf8cf5fc7e404fb27c6360</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32012</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32012</field>
+<field name="lastModifyDate">2018-05-14 14:36:51.122</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32793</identifier><datestamp>2018-05-14T18:46:08Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:22:04Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:22:04Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1962-10-20</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32793</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v31n18_1962-10-20</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1962 October 20th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n18_1962-10-20.txt</field>
+<field name="originalName">MW_v31n18_1962-10-20.txt</field>
+<field name="format">text/plain</field>
+<field name="size">134366</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32793/1/MW_v31n18_1962-10-20.txt</field>
+<field name="checksum">391f2b53b44d218fe0b9f7eb12415ba2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v31n18_1962-10-20.pdf</field>
+<field name="originalName">MW_v31n18_1962-10-20.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">34579437</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32793/2/MW_v31n18_1962-10-20.pdf</field>
+<field name="checksum">4d7a462b27e8b38b53fccbb430730545</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n18_1962-10-20.txt.txt</field>
+<field name="originalName">MW_v31n18_1962-10-20.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">134345</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32793/3/MW_v31n18_1962-10-20.txt.txt</field>
+<field name="checksum">b847dc52099a8f46936cb840fc2372d7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v31n18_1962-10-20.pdf.txt</field>
+<field name="originalName">MW_v31n18_1962-10-20.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32793/4/MW_v31n18_1962-10-20.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n18_1962-10-20.pdf.jpg</field>
+<field name="originalName">MW_v31n18_1962-10-20.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">22571</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32793/5/MW_v31n18_1962-10-20.pdf.jpg</field>
+<field name="checksum">f28d225a5f430f0a2be134a732264730</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32793</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32793</field>
+<field name="lastModifyDate">2018-05-14 13:46:08.735</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31336</identifier><datestamp>2018-05-14T18:46:01Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-01-24T21:15:28Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-01-24T21:15:28Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1968-01-13</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31336</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v36n29_1968-01-13</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1968 January 13th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n29_1968-01-13.pdf.txt</field>
+<field name="originalName">MW_v36n29_1968-01-13.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31336/2/MW_v36n29_1968-01-13.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v36n29_1968-01-13.txt.txt</field>
+<field name="originalName">MW_v36n29_1968-01-13.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">65130</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31336/5/MW_v36n29_1968-01-13.txt.txt</field>
+<field name="checksum">1d7671a7a495b95366f651bf0de1b880</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n29_1968-01-13.pdf.jpg</field>
+<field name="originalName">MW_v36n29_1968-01-13.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">19646</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31336/3/MW_v36n29_1968-01-13.pdf.jpg</field>
+<field name="checksum">878b9263e89968624129b840ebcd5fd5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n29_1968-01-13.pdf</field>
+<field name="originalName">MW_v36n29_1968-01-13.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">20104168</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31336/1/MW_v36n29_1968-01-13.pdf</field>
+<field name="checksum">46af47144755009f2d3911820e7a4274</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v36n29_1968-01-13.txt</field>
+<field name="originalName">MW_v36n29_1968-01-13.txt</field>
+<field name="format">text/plain</field>
+<field name="size">65134</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31336/4/MW_v36n29_1968-01-13.txt</field>
+<field name="checksum">a3b30ad5b689fa454c2c664d2ec9bf77</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31336</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31336</field>
+<field name="lastModifyDate">2018-05-14 13:46:01.93</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32010</identifier><datestamp>2018-05-14T19:36:51Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:54:33Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:54:33Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1952-04-08</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32010</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v20n82_1952-04-08</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1952 April 8th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n82_1952-04-08.pdf</field>
+<field name="originalName">MW_v20n82_1952-04-08.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">42824476</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32010/1/MW_v20n82_1952-04-08.pdf</field>
+<field name="checksum">6cbae62eb54fbc3e32edf21a6288a900</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n82_1952-04-08.txt</field>
+<field name="originalName">MW_v20n82_1952-04-08.txt</field>
+<field name="format">text/plain</field>
+<field name="size">132392</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32010/2/MW_v20n82_1952-04-08.txt</field>
+<field name="checksum">c9cfeb4c33f54ff87d3844f59e76d029</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n82_1952-04-08.pdf.txt</field>
+<field name="originalName">MW_v20n82_1952-04-08.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32010/3/MW_v20n82_1952-04-08.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n82_1952-04-08.txt.txt</field>
+<field name="originalName">MW_v20n82_1952-04-08.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">132391</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32010/5/MW_v20n82_1952-04-08.txt.txt</field>
+<field name="checksum">90fb140dcd3dc937270beb832bda5ff9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n82_1952-04-08.pdf.jpg</field>
+<field name="originalName">MW_v20n82_1952-04-08.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27088</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32010/4/MW_v20n82_1952-04-08.pdf.jpg</field>
+<field name="checksum">18d724633fe5829b03e68853e608c1c8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32010</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32010</field>
+<field name="lastModifyDate">2018-05-14 14:36:51.926</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32299</identifier><datestamp>2018-05-14T19:40:06Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-02T15:18:12Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-02T15:18:12Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1954-06-25</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32299</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v22n86_1954-06-25</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1954 June 25th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n86_1954-06-25.pdf</field>
+<field name="originalName">MW_v22n86_1954-06-25.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">35538164</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32299/1/MW_v22n86_1954-06-25.pdf</field>
+<field name="checksum">8218a1faf66224bd9f894c44b6673338</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v22n86_1954-06-25.txt</field>
+<field name="originalName">MW_v22n86_1954-06-25.txt</field>
+<field name="format">text/plain</field>
+<field name="size">178910</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32299/2/MW_v22n86_1954-06-25.txt</field>
+<field name="checksum">2225db36e1d48a4b3f32af6292f93e1a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n86_1954-06-25.pdf.txt</field>
+<field name="originalName">MW_v22n86_1954-06-25.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32299/3/MW_v22n86_1954-06-25.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v22n86_1954-06-25.txt.txt</field>
+<field name="originalName">MW_v22n86_1954-06-25.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">178892</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32299/5/MW_v22n86_1954-06-25.txt.txt</field>
+<field name="checksum">77e13fe71d6bbf26111e81b3a6967d9d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v22n86_1954-06-25.pdf.jpg</field>
+<field name="originalName">MW_v22n86_1954-06-25.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26947</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32299/4/MW_v22n86_1954-06-25.pdf.jpg</field>
+<field name="checksum">edad0d3424d388b2a3c78523fb2984dd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32299</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32299</field>
+<field name="lastModifyDate">2018-05-14 14:40:06.637</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32191</identifier><datestamp>2018-05-14T19:40:07Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-02T15:14:04Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-02T15:14:04Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1953-01-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32191</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v21n47_1953-01-30</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1953 Juanuary 30th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n47_1953-01-30.pdf</field>
+<field name="originalName">MW_v21n47_1953-01-30.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">43073399</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32191/2/MW_v21n47_1953-01-30.pdf</field>
+<field name="checksum">e72cbee2c0bdc3565390107085432d05</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v21n47_1953-01-30.txt</field>
+<field name="originalName">MW_v21n47_1953-01-30.txt</field>
+<field name="format">text/plain</field>
+<field name="size">339342</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32191/1/MW_v21n47_1953-01-30.txt</field>
+<field name="checksum">93b2df5cd47ac030790f669d2d2c346c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n47_1953-01-30.pdf.txt</field>
+<field name="originalName">MW_v21n47_1953-01-30.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32191/3/MW_v21n47_1953-01-30.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v21n47_1953-01-30.txt.txt</field>
+<field name="originalName">MW_v21n47_1953-01-30.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">339336</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32191/5/MW_v21n47_1953-01-30.txt.txt</field>
+<field name="checksum">c402ad0ab5cdea5c161f4c5f268d109d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v21n47_1953-01-30.pdf.jpg</field>
+<field name="originalName">MW_v21n47_1953-01-30.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26323</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32191/4/MW_v21n47_1953-01-30.pdf.jpg</field>
+<field name="checksum">d601bef38eaa8cec2616cc6ce881e7ca</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32191</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32191</field>
+<field name="lastModifyDate">2018-05-14 14:40:07.616</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32878</identifier><datestamp>2018-05-14T18:46:13Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:23:44Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:23:44Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1964-08-29</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32878</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v33n12_1964-08-29</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1964 August 29th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v33n12_1964-08-29.txt</field>
+<field name="originalName">MW_v33n12_1964-08-29.txt</field>
+<field name="format">text/plain</field>
+<field name="size">74714</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32878/1/MW_v33n12_1964-08-29.txt</field>
+<field name="checksum">5750032b0639af8684d607b5adb47092</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v33n12_1964-08-29.pdf</field>
+<field name="originalName">MW_v33n12_1964-08-29.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32800738</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32878/2/MW_v33n12_1964-08-29.pdf</field>
+<field name="checksum">001e95861296bc8636ca4eb31003e69e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v33n12_1964-08-29.txt.txt</field>
+<field name="originalName">MW_v33n12_1964-08-29.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">74713</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32878/3/MW_v33n12_1964-08-29.txt.txt</field>
+<field name="checksum">56e5d706c91ec7d1433219074a6e4ad1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v33n12_1964-08-29.pdf.txt</field>
+<field name="originalName">MW_v33n12_1964-08-29.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32878/4/MW_v33n12_1964-08-29.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32878</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32878</field>
+<field name="lastModifyDate">2018-05-14 13:46:13.931</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32089</identifier><datestamp>2018-05-14T19:40:03Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:58:37Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:58:37Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1956-02-24</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32089</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v24n71_1956-02-24</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1956 February 24th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n71_1956-02-24.pdf</field>
+<field name="originalName">MW_v24n71_1956-02-24.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">19410229</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32089/1/MW_v24n71_1956-02-24.pdf</field>
+<field name="checksum">66cc403ba18dc2406267b7d32f2b2a33</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n71_1956-02-24.pdf.txt</field>
+<field name="originalName">MW_v24n71_1956-02-24.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32089/2/MW_v24n71_1956-02-24.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v24n71_1956-02-24.pdf.jpg</field>
+<field name="originalName">MW_v24n71_1956-02-24.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21251</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32089/3/MW_v24n71_1956-02-24.pdf.jpg</field>
+<field name="checksum">aa85c523cbbef717c8ac4309b0c40dd4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32089</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32089</field>
+<field name="lastModifyDate">2018-05-14 14:40:03.754</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32907</identifier><datestamp>2018-05-14T18:46:11Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:25:05Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:25:05Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1965-01-09</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32907</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v33n31_1965-01-09</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1965 January 9th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v33n31_1965-01-09.txt.txt</field>
+<field name="originalName">MW_v33n31_1965-01-09.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">136770</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32907/3/MW_v33n31_1965-01-09.txt.txt</field>
+<field name="checksum">239d2a474810215b15e77786a984907a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v33n31_1965-01-09.pdf.txt</field>
+<field name="originalName">MW_v33n31_1965-01-09.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32907/4/MW_v33n31_1965-01-09.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v33n31_1965-01-09.pdf.jpg</field>
+<field name="originalName">MW_v33n31_1965-01-09.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21205</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32907/5/MW_v33n31_1965-01-09.pdf.jpg</field>
+<field name="checksum">c28ccef984cc0b8b3319491fea91eca1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v33n31_1965-01-09.txt</field>
+<field name="originalName">MW_v33n31_1965-01-09.txt</field>
+<field name="format">text/plain</field>
+<field name="size">136814</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32907/1/MW_v33n31_1965-01-09.txt</field>
+<field name="checksum">67cabb9b62de92f05562f28fac2a9448</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v33n31_1965-01-09.pdf</field>
+<field name="originalName">MW_v33n31_1965-01-09.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">33937791</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32907/2/MW_v33n31_1965-01-09.pdf</field>
+<field name="checksum">c0ba735e282f598616746c96b697582e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32907</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32907</field>
+<field name="lastModifyDate">2018-05-14 13:46:11.969</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31656</identifier><datestamp>2018-05-14T18:57:33Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:25Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:25Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-04-28</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31656</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v18n88_1950-04-28</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 April 28th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n88_1950-04-28.pdf</field>
+<field name="originalName">MW_v18n88_1950-04-28.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">18348404</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31656/1/MW_v18n88_1950-04-28.pdf</field>
+<field name="checksum">cf6eadc11f31ae0cac175e4eb58f86be</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n88_1950-04-28.txt</field>
+<field name="originalName">MW_v18n88_1950-04-28.txt</field>
+<field name="format">text/plain</field>
+<field name="size">59238</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31656/2/MW_v18n88_1950-04-28.txt</field>
+<field name="checksum">5158b615157c86ad7ac5caf766ecbdd5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n88_1950-04-28.pdf.txt</field>
+<field name="originalName">MW_v18n88_1950-04-28.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31656/3/MW_v18n88_1950-04-28.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n88_1950-04-28.txt.txt</field>
+<field name="originalName">MW_v18n88_1950-04-28.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">59243</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31656/5/MW_v18n88_1950-04-28.txt.txt</field>
+<field name="checksum">c1a3128ba77b122514e5bf6320927a43</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n88_1950-04-28.pdf.jpg</field>
+<field name="originalName">MW_v18n88_1950-04-28.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">19715</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31656/4/MW_v18n88_1950-04-28.pdf.jpg</field>
+<field name="checksum">0d02e92238e2bdfe6783880257414c09</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31656</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31656</field>
+<field name="lastModifyDate">2018-05-14 13:57:33.758</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32116</identifier><datestamp>2018-05-14T19:40:04Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:58:40Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:58:40Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1956-09-01</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32116</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v25n13_1956-09-01</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1956 September 1st</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v25n13_1956-09-01.pdf.txt</field>
+<field name="originalName">MW_v25n13_1956-09-01.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32116/3/MW_v25n13_1956-09-01.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v25n13_1956-09-01.txt.txt</field>
+<field name="originalName">MW_v25n13_1956-09-01.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">106282</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32116/5/MW_v25n13_1956-09-01.txt.txt</field>
+<field name="checksum">7beb8a67239db2f517ad793518434318</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v25n13_1956-09-01.pdf.jpg</field>
+<field name="originalName">MW_v25n13_1956-09-01.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21073</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32116/4/MW_v25n13_1956-09-01.pdf.jpg</field>
+<field name="checksum">8bf6d67545576fe3aaa816036cb493f1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v25n13_1956-09-01.pdf</field>
+<field name="originalName">MW_v25n13_1956-09-01.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">25913083</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32116/1/MW_v25n13_1956-09-01.pdf</field>
+<field name="checksum">4fe127a3e1791e81b49a461d3435ee02</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v25n13_1956-09-01.txt</field>
+<field name="originalName">MW_v25n13_1956-09-01.txt</field>
+<field name="format">text/plain</field>
+<field name="size">106282</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32116/2/MW_v25n13_1956-09-01.txt</field>
+<field name="checksum">973ffb85992e69318688f976d7c07aaf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32116</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32116</field>
+<field name="lastModifyDate">2018-05-14 14:40:04.461</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33148</identifier><datestamp>2018-05-14T19:38:14Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-23T14:12:27Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-23T14:12:27Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1957-03-27</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33148</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v26n19_1957-03-27</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1957 March 27th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v26n19_1957-03-27.pdf</field>
+<field name="originalName">MW_v26n19_1957-03-27.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">29094792</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33148/1/MW_v26n19_1957-03-27.pdf</field>
+<field name="checksum">0c933a11dbe9cb0b2d9730e95996802c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v26n19_1957-03-27.txt</field>
+<field name="originalName">MW_v26n19_1957-03-27.txt</field>
+<field name="format">text/plain</field>
+<field name="size">100572</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33148/2/MW_v26n19_1957-03-27.txt</field>
+<field name="checksum">fb0bcf70ec0e02e69dc8b46ea203016f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v26n19_1957-03-27.pdf.txt</field>
+<field name="originalName">MW_v26n19_1957-03-27.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33148/3/MW_v26n19_1957-03-27.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v26n19_1957-03-27.txt.txt</field>
+<field name="originalName">MW_v26n19_1957-03-27.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">100566</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33148/5/MW_v26n19_1957-03-27.txt.txt</field>
+<field name="checksum">12c17d266d9cdfaeaa8b10b0e4af7948</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v26n19_1957-03-27.pdf.jpg</field>
+<field name="originalName">MW_v26n19_1957-03-27.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27497</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33148/4/MW_v26n19_1957-03-27.pdf.jpg</field>
+<field name="checksum">905b51ecad1061ce03581101a1fdd3bb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33148</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33148</field>
+<field name="lastModifyDate">2018-05-14 14:38:14.258</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33154</identifier><datestamp>2018-05-14T19:38:13Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-23T14:12:28Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-23T14:12:28Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1957-04-13</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33154</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v26n24_1957-04-13</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1957 April 13th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v26n24_1957-04-13.txt</field>
+<field name="originalName">MW_v26n24_1957-04-13.txt</field>
+<field name="format">text/plain</field>
+<field name="size">149404</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33154/1/MW_v26n24_1957-04-13.txt</field>
+<field name="checksum">1d4ca4e9eba0a8c9f47b71ca1227a83a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v26n24_1957-04-13.txt.txt</field>
+<field name="originalName">MW_v26n24_1957-04-13.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">149406</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33154/2/MW_v26n24_1957-04-13.txt.txt</field>
+<field name="checksum">30eadd7742679904e511d8bbe1cb6644</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33154</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33154</field>
+<field name="lastModifyDate">2018-05-14 14:38:13.024</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31684</identifier><datestamp>2018-05-14T18:57:34Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:27Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:27Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-09-01</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31684</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v19n21_1950-09-01</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 September 1st</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n21_1950-09-01.pdf.txt</field>
+<field name="originalName">MW_v19n21_1950-09-01.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31684/3/MW_v19n21_1950-09-01.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n21_1950-09-01.txt.txt</field>
+<field name="originalName">MW_v19n21_1950-09-01.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">73041</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31684/5/MW_v19n21_1950-09-01.txt.txt</field>
+<field name="checksum">69ca9923c7c63c77b6b7982508cfd78d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n21_1950-09-01.pdf.jpg</field>
+<field name="originalName">MW_v19n21_1950-09-01.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">20691</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31684/4/MW_v19n21_1950-09-01.pdf.jpg</field>
+<field name="checksum">d12c6e06ec50f91d0b551333eeecf214</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n21_1950-09-01.pdf</field>
+<field name="originalName">MW_v19n21_1950-09-01.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">22501800</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31684/1/MW_v19n21_1950-09-01.pdf</field>
+<field name="checksum">78bdf661530640ad0cf56067c068c84e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n21_1950-09-01.txt</field>
+<field name="originalName">MW_v19n21_1950-09-01.txt</field>
+<field name="format">text/plain</field>
+<field name="size">73038</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31684/2/MW_v19n21_1950-09-01.txt</field>
+<field name="checksum">e0da94a7ffcc8100387a5a38ec9a7da0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31684</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31684</field>
+<field name="lastModifyDate">2018-05-14 13:57:34.38</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31633</identifier><datestamp>2018-05-14T18:57:34Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:23Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:23Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-02-07</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31633</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v18n65_1950-02-07</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 February 7th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n65_1950-02-07.pdf.txt</field>
+<field name="originalName">MW_v18n65_1950-02-07.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31633/3/MW_v18n65_1950-02-07.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n65_1950-02-07.txt.txt</field>
+<field name="originalName">MW_v18n65_1950-02-07.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">98117</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31633/5/MW_v18n65_1950-02-07.txt.txt</field>
+<field name="checksum">963a05cb4e89528fce793085ffff6655</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n65_1950-02-07.pdf.jpg</field>
+<field name="originalName">MW_v18n65_1950-02-07.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">18903</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31633/4/MW_v18n65_1950-02-07.pdf.jpg</field>
+<field name="checksum">dcc24010838353c5ab836c9883c99ecc</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v18n65_1950-02-07.pdf</field>
+<field name="originalName">MW_v18n65_1950-02-07.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">16547557</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31633/1/MW_v18n65_1950-02-07.pdf</field>
+<field name="checksum">e4fbb2740aa675fa237148dbf655f3b0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v18n65_1950-02-07.txt</field>
+<field name="originalName">MW_v18n65_1950-02-07.txt</field>
+<field name="format">text/plain</field>
+<field name="size">98118</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31633/2/MW_v18n65_1950-02-07.txt</field>
+<field name="checksum">6ab611b82b1ffd424f3bfc238c491797</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31633</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31633</field>
+<field name="lastModifyDate">2018-05-14 13:57:34.678</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32719</identifier><datestamp>2018-05-14T18:46:06Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:18:43Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:18:43Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1960-08-06</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32719</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v30n3_1960-08-06</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1960 August 6th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n3_1960-08-06.txt</field>
+<field name="originalName">MW_v30n3_1960-08-06.txt</field>
+<field name="format">text/plain</field>
+<field name="size">56388</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32719/1/MW_v30n3_1960-08-06.txt</field>
+<field name="checksum">ff748acdd8211ea5df3dd507f875685a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n3_1960-08-06.pdf</field>
+<field name="originalName">MW_v30n3_1960-08-06.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">42177322</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32719/2/MW_v30n3_1960-08-06.pdf</field>
+<field name="checksum">e6d743e1dc167fad13bf1250b8989c70</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n3_1960-08-06.txt.txt</field>
+<field name="originalName">MW_v30n3_1960-08-06.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">56390</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32719/3/MW_v30n3_1960-08-06.txt.txt</field>
+<field name="checksum">a3781511ce5add51bb1d22ad3aa8d15e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n3_1960-08-06.pdf.txt</field>
+<field name="originalName">MW_v30n3_1960-08-06.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32719/4/MW_v30n3_1960-08-06.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n3_1960-08-06.pdf.jpg</field>
+<field name="originalName">MW_v30n3_1960-08-06.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">24028</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32719/5/MW_v30n3_1960-08-06.pdf.jpg</field>
+<field name="checksum">452b16698fc876a89d77b715688f7037</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32719</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32719</field>
+<field name="lastModifyDate">2018-05-14 13:46:06.213</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33292</identifier><datestamp>2018-05-14T18:46:15Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-24T17:58:20Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-24T17:58:20Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1969-06-07</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33292</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v37n48_1969-06-07</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1969 June 7th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v37n48_1969-06-07.txt</field>
+<field name="originalName">MW_v37n48_1969-06-07.txt</field>
+<field name="format">text/plain</field>
+<field name="size">25296</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33292/1/MW_v37n48_1969-06-07.txt</field>
+<field name="checksum">fbfcaa831eadfb24a60927462e4f7ec7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v37n48_1969-06-07.pdf</field>
+<field name="originalName">MW_v37n48_1969-06-07.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32827793</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33292/2/MW_v37n48_1969-06-07.pdf</field>
+<field name="checksum">ba78c2f78ab3286f709eac9dc386b65a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v37n48_1969-06-07.txt.txt</field>
+<field name="originalName">MW_v37n48_1969-06-07.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">25297</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33292/3/MW_v37n48_1969-06-07.txt.txt</field>
+<field name="checksum">899dbe2b4d7dac673915406b06599605</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v37n48_1969-06-07.pdf.txt</field>
+<field name="originalName">MW_v37n48_1969-06-07.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33292/4/MW_v37n48_1969-06-07.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v37n48_1969-06-07.pdf.jpg</field>
+<field name="originalName">MW_v37n48_1969-06-07.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">25167</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33292/5/MW_v37n48_1969-06-07.pdf.jpg</field>
+<field name="checksum">f81b5a2674892f59d0115c5c0dcf356f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33292</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33292</field>
+<field name="lastModifyDate">2018-05-14 13:46:15.014</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33049</identifier><datestamp>2018-05-14T18:46:12Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:26:45Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:26:45Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1967-07-15</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33049</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v36n3_1967-07-15</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1967 July 15th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n3_1967-07-15.pdf</field>
+<field name="originalName">MW_v36n3_1967-07-15.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32077724</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33049/1/MW_v36n3_1967-07-15.pdf</field>
+<field name="checksum">f03fd4e09db4f71985d82426ab02c37b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v36n3_1967-07-15.txt</field>
+<field name="originalName">MW_v36n3_1967-07-15.txt</field>
+<field name="format">text/plain</field>
+<field name="size">80972</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33049/2/MW_v36n3_1967-07-15.txt</field>
+<field name="checksum">aa92a4efab54cce2121c3eed3f717931</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n3_1967-07-15.pdf.txt</field>
+<field name="originalName">MW_v36n3_1967-07-15.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33049/3/MW_v36n3_1967-07-15.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v36n3_1967-07-15.txt.txt</field>
+<field name="originalName">MW_v36n3_1967-07-15.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">80972</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33049/5/MW_v36n3_1967-07-15.txt.txt</field>
+<field name="checksum">f5b9c0e61cb39d872733c8f5a8321dbe</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n3_1967-07-15.pdf.jpg</field>
+<field name="originalName">MW_v36n3_1967-07-15.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21804</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33049/4/MW_v36n3_1967-07-15.pdf.jpg</field>
+<field name="checksum">b03378b17b9e1bed0c1da60e8219c4ad</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33049</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33049</field>
+<field name="lastModifyDate">2018-05-14 13:46:12.708</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32808</identifier><datestamp>2018-05-14T18:46:08Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:22:53Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:22:53Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1963-02-02</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32808</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v31n33_1963-02-02</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1963 February 2nd</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n33_1963-02-02.txt</field>
+<field name="originalName">MW_v31n33_1963-02-02.txt</field>
+<field name="format">text/plain</field>
+<field name="size">54896</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32808/1/MW_v31n33_1963-02-02.txt</field>
+<field name="checksum">519ea36ed697e1770ac5047234febb1b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v31n33_1963-02-02.pdf</field>
+<field name="originalName">MW_v31n33_1963-02-02.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">39548065</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32808/2/MW_v31n33_1963-02-02.pdf</field>
+<field name="checksum">4dea6bd280e596ec59f1e17cc64b70c6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n33_1963-02-02.txt.txt</field>
+<field name="originalName">MW_v31n33_1963-02-02.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">54889</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32808/3/MW_v31n33_1963-02-02.txt.txt</field>
+<field name="checksum">e734c11751c59556c94f1ff596b462f1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v31n33_1963-02-02.pdf.txt</field>
+<field name="originalName">MW_v31n33_1963-02-02.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32808/4/MW_v31n33_1963-02-02.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v31n33_1963-02-02.pdf.jpg</field>
+<field name="originalName">MW_v31n33_1963-02-02.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">23655</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32808/5/MW_v31n33_1963-02-02.pdf.jpg</field>
+<field name="checksum">6f77b01c30e044e33ebab7fdf2d37381</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32808</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32808</field>
+<field name="lastModifyDate">2018-05-14 13:46:08.381</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31706</identifier><datestamp>2018-05-14T18:57:33Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:29Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:29Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-11-14</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31706</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v19n42_1950-11-14</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 November 14th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n42_1950-11-14.txt.txt</field>
+<field name="originalName">MW_v19n42_1950-11-14.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">89999</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31706/3/MW_v19n42_1950-11-14.txt.txt</field>
+<field name="checksum">0d13d558c7ef308dfaa65ec5633583c7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n42_1950-11-14.pdf.txt</field>
+<field name="originalName">MW_v19n42_1950-11-14.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31706/4/MW_v19n42_1950-11-14.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n42_1950-11-14.pdf.jpg</field>
+<field name="originalName">MW_v19n42_1950-11-14.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">19536</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31706/5/MW_v19n42_1950-11-14.pdf.jpg</field>
+<field name="checksum">f0c514728102d0ec386c9a458c177ac4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n42_1950-11-14.txt</field>
+<field name="originalName">MW_v19n42_1950-11-14.txt</field>
+<field name="format">text/plain</field>
+<field name="size">89994</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31706/1/MW_v19n42_1950-11-14.txt</field>
+<field name="checksum">5719a7ca9d17a062429d1b19c93f290a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n42_1950-11-14.pdf</field>
+<field name="originalName">MW_v19n42_1950-11-14.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">14921099</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31706/2/MW_v19n42_1950-11-14.pdf</field>
+<field name="checksum">ede25a34dd3fde9bf16c64267b691562</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31706</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31706</field>
+<field name="lastModifyDate">2018-05-14 13:57:33.212</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31671</identifier><datestamp>2018-05-14T18:57:33Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-02-26T17:00:26Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-02-26T17:00:26Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1950-07-21</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31671</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v19n09_1950-07-21</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1950 July 21st</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n09_1950-07-21.pdf</field>
+<field name="originalName">MW_v19n09_1950-07-21.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">17267974</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31671/1/MW_v19n09_1950-07-21.pdf</field>
+<field name="checksum">2b5778d698ca4f43911e51b4da31cbe9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n09_1950-07-21.txt</field>
+<field name="originalName">MW_v19n09_1950-07-21.txt</field>
+<field name="format">text/plain</field>
+<field name="size">201112</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31671/2/MW_v19n09_1950-07-21.txt</field>
+<field name="checksum">8e484be1b4041ec26a23bf679530fb94</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n09_1950-07-21.pdf.txt</field>
+<field name="originalName">MW_v19n09_1950-07-21.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31671/3/MW_v19n09_1950-07-21.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v19n09_1950-07-21.txt.txt</field>
+<field name="originalName">MW_v19n09_1950-07-21.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">201113</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31671/5/MW_v19n09_1950-07-21.txt.txt</field>
+<field name="checksum">7cbf8be6c23dd57d670d073acf9b2f85</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v19n09_1950-07-21.pdf.jpg</field>
+<field name="originalName">MW_v19n09_1950-07-21.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21570</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31671/4/MW_v19n09_1950-07-21.pdf.jpg</field>
+<field name="checksum">2040f18fb50964139c42033333ff7c8d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31671</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31671</field>
+<field name="lastModifyDate">2018-05-14 13:57:33.861</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33001</identifier><datestamp>2018-05-14T18:46:08Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:26:08Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:26:08Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1966-08-13</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33001</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v35n6_1966-08-13</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1966 August 13th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v35n6_1966-08-13.pdf</field>
+<field name="originalName">MW_v35n6_1966-08-13.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">34544218</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33001/1/MW_v35n6_1966-08-13.pdf</field>
+<field name="checksum">158a1e168e6db022968d0f0f3459de6f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v35n6_1966-08-13.txt</field>
+<field name="originalName">MW_v35n6_1966-08-13.txt</field>
+<field name="format">text/plain</field>
+<field name="size">76186</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33001/2/MW_v35n6_1966-08-13.txt</field>
+<field name="checksum">ac345d17d53d10ba22a7640100579889</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v35n6_1966-08-13.pdf.txt</field>
+<field name="originalName">MW_v35n6_1966-08-13.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33001/3/MW_v35n6_1966-08-13.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v35n6_1966-08-13.txt.txt</field>
+<field name="originalName">MW_v35n6_1966-08-13.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">76188</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33001/5/MW_v35n6_1966-08-13.txt.txt</field>
+<field name="checksum">58b2be381abf3c30703ded4520ee4ea8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v35n6_1966-08-13.pdf.jpg</field>
+<field name="originalName">MW_v35n6_1966-08-13.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">22437</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33001/4/MW_v35n6_1966-08-13.pdf.jpg</field>
+<field name="checksum">6536133ebc951f87d2a0163a8c2574e2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33001</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33001</field>
+<field name="lastModifyDate">2018-05-14 13:46:08.369</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31386</identifier><datestamp>2018-05-14T18:45:55Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-01-24T21:15:36Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-01-24T21:15:36Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1968-12-25</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31386</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v37n26_1968-12-25</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1968 December 25th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v37n26_1968-12-25.pdf</field>
+<field name="originalName">MW_v37n26_1968-12-25.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">12386828</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31386/1/MW_v37n26_1968-12-25.pdf</field>
+<field name="checksum">0d249813ee28c04a7dd3ded78739a6eb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v37n26_1968-12-25.txt</field>
+<field name="originalName">MW_v37n26_1968-12-25.txt</field>
+<field name="format">text/plain</field>
+<field name="size">42470</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31386/4/MW_v37n26_1968-12-25.txt</field>
+<field name="checksum">bbb3ee8f1e25816151486fdb085d3c73</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v37n26_1968-12-25.pdf.txt</field>
+<field name="originalName">MW_v37n26_1968-12-25.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31386/2/MW_v37n26_1968-12-25.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v37n26_1968-12-25.txt.txt</field>
+<field name="originalName">MW_v37n26_1968-12-25.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">42471</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31386/5/MW_v37n26_1968-12-25.txt.txt</field>
+<field name="checksum">a74e244e87a2e615f9c528dc88b57bcc</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v37n26_1968-12-25.pdf.jpg</field>
+<field name="originalName">MW_v37n26_1968-12-25.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">19921</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31386/3/MW_v37n26_1968-12-25.pdf.jpg</field>
+<field name="checksum">b43d6ab8ec9220ffc151a994b5d7c715</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31386</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31386</field>
+<field name="lastModifyDate">2018-05-14 13:45:55.738</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33089</identifier><datestamp>2018-05-14T18:54:58Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:28:27Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:28:27Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1970-09-05</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33089</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v38n50_1970-09-05</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1970 September 5th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v38n50_1970-09-05.txt</field>
+<field name="originalName">MW_v38n50_1970-09-05.txt</field>
+<field name="format">text/plain</field>
+<field name="size">57424</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33089/1/MW_v38n50_1970-09-05.txt</field>
+<field name="checksum">3290c6ac24bfb12cca3ab668cc36eea1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v38n50_1970-09-05.pdf</field>
+<field name="originalName">MW_v38n50_1970-09-05.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">30061784</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33089/2/MW_v38n50_1970-09-05.pdf</field>
+<field name="checksum">27992ef2f4ae9a288faea62588610a72</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v38n50_1970-09-05.txt.txt</field>
+<field name="originalName">MW_v38n50_1970-09-05.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">57424</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33089/3/MW_v38n50_1970-09-05.txt.txt</field>
+<field name="checksum">24dd7bdd2a419ced85971180a63de9b8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v38n50_1970-09-05.pdf.txt</field>
+<field name="originalName">MW_v38n50_1970-09-05.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33089/4/MW_v38n50_1970-09-05.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v38n50_1970-09-05.pdf.jpg</field>
+<field name="originalName">MW_v38n50_1970-09-05.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">24017</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33089/5/MW_v38n50_1970-09-05.pdf.jpg</field>
+<field name="checksum">a469059c2adb56366f1d456a37baa3d9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33089</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33089</field>
+<field name="lastModifyDate">2018-05-14 13:54:58.261</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31970</identifier><datestamp>2018-05-14T19:36:51Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:54:26Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:54:26Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1952-06-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31970</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v20n102_1952-06-17</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1952 June 17th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n102_1952-06-17.pdf</field>
+<field name="originalName">MW_v20n102_1952-06-17.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">47401603</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31970/1/MW_v20n102_1952-06-17.pdf</field>
+<field name="checksum">743044827880803af3fffc9db583d5af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n102_1952-06-17.txt</field>
+<field name="originalName">MW_v20n102_1952-06-17.txt</field>
+<field name="format">text/plain</field>
+<field name="size">91712</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31970/2/MW_v20n102_1952-06-17.txt</field>
+<field name="checksum">618deb649859094898bfd8b5134d14c5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n102_1952-06-17.pdf.txt</field>
+<field name="originalName">MW_v20n102_1952-06-17.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31970/3/MW_v20n102_1952-06-17.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n102_1952-06-17.txt.txt</field>
+<field name="originalName">MW_v20n102_1952-06-17.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">91716</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31970/5/MW_v20n102_1952-06-17.txt.txt</field>
+<field name="checksum">d9718a36a12f262d3e715071064e8254</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n102_1952-06-17.pdf.jpg</field>
+<field name="originalName">MW_v20n102_1952-06-17.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">25378</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31970/4/MW_v20n102_1952-06-17.pdf.jpg</field>
+<field name="checksum">595e273cbc595eb404ce78eb811bb5a5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31970</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31970</field>
+<field name="lastModifyDate">2018-05-14 14:36:51.947</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32390</identifier><datestamp>2018-05-14T19:40:09Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:20:55Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:20:55Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1955-05-20</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32390</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v23n93_1955-05-20</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1955 May 20th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n93_1955-05-20.pdf</field>
+<field name="originalName">MW_v23n93_1955-05-20.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">39943593</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32390/1/MW_v23n93_1955-05-20.pdf</field>
+<field name="checksum">f157001f7860ea2c330169ab2f2fc0b0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n93_1955-05-20.txt</field>
+<field name="originalName">MW_v23n93_1955-05-20.txt</field>
+<field name="format">text/plain</field>
+<field name="size">52932</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32390/2/MW_v23n93_1955-05-20.txt</field>
+<field name="checksum">07e9022dbc5337cb85a5a5ca3ce57979</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n93_1955-05-20.pdf.txt</field>
+<field name="originalName">MW_v23n93_1955-05-20.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32390/3/MW_v23n93_1955-05-20.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v23n93_1955-05-20.txt.txt</field>
+<field name="originalName">MW_v23n93_1955-05-20.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">52937</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32390/5/MW_v23n93_1955-05-20.txt.txt</field>
+<field name="checksum">5acb58a6090860dce6ba55d941f1b1fd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v23n93_1955-05-20.pdf.jpg</field>
+<field name="originalName">MW_v23n93_1955-05-20.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">25396</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32390/4/MW_v23n93_1955-05-20.pdf.jpg</field>
+<field name="checksum">274f4a1df7c24f78984eb4bd1b553554</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32390</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32390</field>
+<field name="lastModifyDate">2018-05-14 14:40:09.16</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32013</identifier><datestamp>2018-05-14T19:36:51Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-03-20T18:54:33Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-03-20T18:54:33Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1952-04-18</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32013</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v20n85_1952-04-18</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1952 April 18th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n85_1952-04-18.pdf</field>
+<field name="originalName">MW_v20n85_1952-04-18.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">38770042</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32013/1/MW_v20n85_1952-04-18.pdf</field>
+<field name="checksum">430385ecdc9023dc63fd0bd252b2f590</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n85_1952-04-18.txt</field>
+<field name="originalName">MW_v20n85_1952-04-18.txt</field>
+<field name="format">text/plain</field>
+<field name="size">157992</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32013/2/MW_v20n85_1952-04-18.txt</field>
+<field name="checksum">96e701b7abfaabcf1f406eae15e8588c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n85_1952-04-18.pdf.txt</field>
+<field name="originalName">MW_v20n85_1952-04-18.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32013/3/MW_v20n85_1952-04-18.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v20n85_1952-04-18.txt.txt</field>
+<field name="originalName">MW_v20n85_1952-04-18.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">157868</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32013/5/MW_v20n85_1952-04-18.txt.txt</field>
+<field name="checksum">019637e00be6930872a3e0c96abba462</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v20n85_1952-04-18.pdf.jpg</field>
+<field name="originalName">MW_v20n85_1952-04-18.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">26587</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32013/4/MW_v20n85_1952-04-18.pdf.jpg</field>
+<field name="checksum">e81119fd2ca5d2b32ecdd7ec4436d890</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32013</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32013</field>
+<field name="lastModifyDate">2018-05-14 14:36:51.191</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33047</identifier><datestamp>2018-05-14T18:46:10Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:26:45Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:26:45Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1967-12-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33047</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v36n27_1967-12-30</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1967 December 30th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n27_1967-12-30.pdf.txt</field>
+<field name="originalName">MW_v36n27_1967-12-30.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33047/3/MW_v36n27_1967-12-30.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v36n27_1967-12-30.txt.txt</field>
+<field name="originalName">MW_v36n27_1967-12-30.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">95996</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33047/5/MW_v36n27_1967-12-30.txt.txt</field>
+<field name="checksum">ec255632a671b43cc68f210ca61e9158</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n27_1967-12-30.pdf.jpg</field>
+<field name="originalName">MW_v36n27_1967-12-30.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">21053</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33047/4/MW_v36n27_1967-12-30.pdf.jpg</field>
+<field name="checksum">7b7f426420a3582f7cdbb226fe5446a3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v36n27_1967-12-30.pdf</field>
+<field name="originalName">MW_v36n27_1967-12-30.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32348977</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33047/1/MW_v36n27_1967-12-30.pdf</field>
+<field name="checksum">99618024fd7d61d7ff22f956e1672d1e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v36n27_1967-12-30.txt</field>
+<field name="originalName">MW_v36n27_1967-12-30.txt</field>
+<field name="format">text/plain</field>
+<field name="size">96006</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33047/2/MW_v36n27_1967-12-30.txt</field>
+<field name="checksum">b2c884c70b52373ea242c1aa06f209ac</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33047</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33047</field>
+<field name="lastModifyDate">2018-05-14 13:46:10.583</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32482</identifier><datestamp>2018-05-14T19:25:36Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-06T20:22:05Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-06T20:22:05Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1958-05-14</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32482</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v27n85_1958-05-14</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1958 May 14th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n85_1958-05-14.pdf</field>
+<field name="originalName">MW_v27n85_1958-05-14.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">25612660</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32482/1/MW_v27n85_1958-05-14.pdf</field>
+<field name="checksum">9f3d38b842ceee9db11e1e7d96e299d0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v27n85_1958-05-14.txt</field>
+<field name="originalName">MW_v27n85_1958-05-14.txt</field>
+<field name="format">text/plain</field>
+<field name="size">167964</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32482/2/MW_v27n85_1958-05-14.txt</field>
+<field name="checksum">4808b2055562b584abcf8caa5b96dfda</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n85_1958-05-14.pdf.txt</field>
+<field name="originalName">MW_v27n85_1958-05-14.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32482/3/MW_v27n85_1958-05-14.pdf.txt</field>
+<field name="checksum">6d93d3216dc4a7f5df47d4876fbec4d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v27n85_1958-05-14.txt.txt</field>
+<field name="originalName">MW_v27n85_1958-05-14.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">167973</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32482/5/MW_v27n85_1958-05-14.txt.txt</field>
+<field name="checksum">ed64d0c4f4f81a9837f1882fdb0648ef</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v27n85_1958-05-14.pdf.jpg</field>
+<field name="originalName">MW_v27n85_1958-05-14.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">27620</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32482/4/MW_v27n85_1958-05-14.pdf.jpg</field>
+<field name="checksum">74b9a6905f53ed123d9e3fb8bd97beac</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32482</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32482</field>
+<field name="lastModifyDate">2018-05-14 14:25:36.432</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33020</identifier><datestamp>2018-05-14T18:46:10Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:26:43Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:26:43Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1967-04-29</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33020</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v35n44_1967-04-29</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1967 April 29th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v35n44_1967-04-29.pdf.txt</field>
+<field name="originalName">MW_v35n44_1967-04-29.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33020/3/MW_v35n44_1967-04-29.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v35n44_1967-04-29.txt.txt</field>
+<field name="originalName">MW_v35n44_1967-04-29.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">66700</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33020/5/MW_v35n44_1967-04-29.txt.txt</field>
+<field name="checksum">32025fcae5017d82c7ef04b71cb3c014</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v35n44_1967-04-29.pdf.jpg</field>
+<field name="originalName">MW_v35n44_1967-04-29.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">18902</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33020/4/MW_v35n44_1967-04-29.pdf.jpg</field>
+<field name="checksum">283eee258acbdacc8bf459409bf46c4a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v35n44_1967-04-29.pdf</field>
+<field name="originalName">MW_v35n44_1967-04-29.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">32164056</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33020/1/MW_v35n44_1967-04-29.pdf</field>
+<field name="checksum">3a3994e94663e9709e6c237d58584a27</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v35n44_1967-04-29.txt</field>
+<field name="originalName">MW_v35n44_1967-04-29.txt</field>
+<field name="format">text/plain</field>
+<field name="size">66704</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33020/2/MW_v35n44_1967-04-29.txt</field>
+<field name="checksum">f5beee52723cc0aebe94d8c99debc9dd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33020</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33020</field>
+<field name="lastModifyDate">2018-05-14 13:46:10.606</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/32749</identifier><datestamp>2018-05-14T18:46:04Z</datestamp><setSpec>com_10267_31327</setSpec><setSpec>com_10267_30688</setSpec><setSpec>col_10267_31334</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="editor">
+<element name="none">
+<field name="value">Beauchamp, J. A.</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-10T19:18:46Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-10T19:18:46Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1960-11-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/32749</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">MW_v30n33_1960-11-19</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Memphis World Publishing Co.</field>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Newspapers</field>
+<field name="value">Civil rights</field>
+<field name="value">Race</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Memphis World, 1960 November 19th</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Text</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n33_1960-11-19.txt</field>
+<field name="originalName">MW_v30n33_1960-11-19.txt</field>
+<field name="format">text/plain</field>
+<field name="size">137498</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32749/1/MW_v30n33_1960-11-19.txt</field>
+<field name="checksum">eed979ef8f8a5e23b7ba29d3e48bd9b4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n33_1960-11-19.pdf</field>
+<field name="originalName">MW_v30n33_1960-11-19.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">42417919</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32749/2/MW_v30n33_1960-11-19.pdf</field>
+<field name="checksum">493deaec0eaca60ff41c88abc8b8a647</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n33_1960-11-19.txt.txt</field>
+<field name="originalName">MW_v30n33_1960-11-19.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">137497</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32749/3/MW_v30n33_1960-11-19.txt.txt</field>
+<field name="checksum">a857b28c4603c88ffb9b8585ea651022</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">MW_v30n33_1960-11-19.pdf.txt</field>
+<field name="originalName">MW_v30n33_1960-11-19.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32749/4/MW_v30n33_1960-11-19.pdf.txt</field>
+<field name="checksum">8d1b69dd9bdc9df4a8073c7a8193c7af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">MW_v30n33_1960-11-19.pdf.jpg</field>
+<field name="originalName">MW_v30n33_1960-11-19.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">23165</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/32749/5/MW_v30n33_1960-11-19.pdf.jpg</field>
+<field name="checksum">48d47834b051fa0d9d38fb849fd977a9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/32749</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/32749</field>
+<field name="lastModifyDate">2018-05-14 13:46:04.792</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><resumptionToken completeListSize="1484" cursor="0">xoai///col_10267_31334/100</resumptionToken></ListRecords></OAI-PMH>


### PR DESCRIPTION
**GitHub Issue**: [DLTN_XSLT-103](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/103)

* [OAI](http://dlynx.rhodes.edu:8080/oai/request?verb=ListRecords&metadataPrefix=xoai&set=col_10267_31334)
* [Digital Collection](http://dlynx.rhodes.edu/jspui/handle/10267/31334)
* [Mapping](https://dltn-technical-docs.readthedocs.io/en/latest/mappings/crossroads.html#col-10267-31334-memphis-world)

## What does this Pull Request do?

Adds a metadata record to test the Memphis World set before going to Repox.

## What's new?

A test record.

## How should this be tested?

1. **REVIEW, APPROVE, AND MERGE [PR-102](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/pull/102)**.
2. Use the rhodes_dspaces_xoai_to_mods.xsl transform.  Since this P.R. hasn't been reviewed and the file is not yet tracked upstream, I kept updating the same transform to keep things easier for us going forward.
3. Does the MODS record look right based off the mapping above?
4. Does everything have a title, a rights, a thumbnail and isShownAt, and a dataProvider?

## Additional Notes:

Again, we need to handle pull request 102 first.

## Interested parties

@mlhale7 
