### PR TITLE
Add sample record & transform changes for Rhodes Oral Histories.

### DIFF
--- a/Sample_Data/Crossroads/oral_histories.xml
+++ b/Sample_Data/Crossroads/oral_histories.xml
@@ -1,0 +1,17508 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/style.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2019-01-28T05:13:59Z</responseDate><request verb="ListRecords" metadataPrefix="xoai" set="col_10267_30936">http://dlynx.rhodes.edu:8080/oai/request</request><ListRecords><record><header><identifier>oai:dlynx.rhodes.edu:10267/33559</identifier><datestamp>2018-07-12T18:20:38Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Wolff, Bert</field>
+<field name="value">Davis, Francesca</field>
+<field name="value">Windless, Crystal</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T15:16:06Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T15:16:06Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2006-12-20</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33559</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20061220_Bert_Wolff</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Bert Wolff was and continues to be involved in many activities in the city of Memphis. A 5th generation Jewish woman with a rich sense of family history, she participated in various interracial organizations to improve the status of African Americans. For example, she was a representative on the Panel of American Women, an organization that traveled to various locations where women from different races and backgrounds would discuss their unique experiences of race and gender. In addition, Wolff was the president of the Memphis City School Board in 1983, an election year. Serving in this position she had the deciding controversial vote to integrate the Raleigh Bartlett schools which were newly annexed into the city of Memphis. After her vote, Wolff was not re-elected to the school board. Nevertheless,Wolff remained very active in the Memphis community and can be considered a pivotal agent of change.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278548334</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Religion</field>
+<field name="value">Memphis City Schools</field>
+<field name="value">Education</field>
+<field name="value">Panel of American Women</field>
+<field name="value">Gender</field>
+<field name="value">Segregation</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Bert Wolff, 2006</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061220_Bert_Wolff.jpg</field>
+<field name="originalName">20061220_Bert_Wolff.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">229720</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33559/1/20061220_Bert_Wolff.jpg</field>
+<field name="checksum">3c4710b65e0b8aa91b2d490abeff2446</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20061220_Bert_Wolff.pdf</field>
+<field name="originalName">20061220_Bert_Wolff.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">159592</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33559/2/20061220_Bert_Wolff.pdf</field>
+<field name="checksum">f6770490a5b4b0b1fa52444adee63bb6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061220_Bert_Wolff.jpg.jpg</field>
+<field name="originalName">20061220_Bert_Wolff.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">14080</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33559/3/20061220_Bert_Wolff.jpg.jpg</field>
+<field name="checksum">d3250fc0ed75d8fdde94fb95876ac5fd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20061220_Bert_Wolff.pdf.jpg</field>
+<field name="originalName">20061220_Bert_Wolff.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">16134</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33559/6/20061220_Bert_Wolff.pdf.jpg</field>
+<field name="checksum">70d4e8fd9fd43df80d7510ff772c4438</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061220_Bert_Wolff.jpg.preview.jpg</field>
+<field name="originalName">20061220_Bert_Wolff.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">57892</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33559/4/20061220_Bert_Wolff.jpg.preview.jpg</field>
+<field name="checksum">6c2b2e54b7152944f422663ac4172fae</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061220_Bert_Wolff.pdf.txt</field>
+<field name="originalName">20061220_Bert_Wolff.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">37743</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33559/5/20061220_Bert_Wolff.pdf.txt</field>
+<field name="checksum">a2be8511c5f0287c9463ed98afe36b76</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33559</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33559</field>
+<field name="lastModifyDate">2018-07-12 13:20:38.341</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33556</identifier><datestamp>2018-07-12T18:20:38Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Ray, Edward (Eddie)</field>
+<field name="value">Windless, Crystal</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T15:16:05Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T15:16:05Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2006-10-04</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33556</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20061004_Eddie_Ray</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Mr. Ray was a high level executive in the music industry and a US commissioner for copyright matters in Washington, D.C. In this interview he discusses his childhood, his experiences in the music industry and his work with community organizations.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278539946</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Music</field>
+<field name="value">Law</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Eddie Ray, 2006</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061004_Eddie_Ray.jpg.jpg</field>
+<field name="originalName">20061004_Eddie_Ray.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">16003</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33556/3/20061004_Eddie_Ray.jpg.jpg</field>
+<field name="checksum">952049355519c80551a900a14288dd38</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20061004_ Eddie_Ray.pdf.jpg</field>
+<field name="originalName">20061004_ Eddie_Ray.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13188</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33556/6/20061004_%20Eddie_Ray.pdf.jpg</field>
+<field name="checksum">3064cffa38921e595f670d3d9f0fa393</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061004_Eddie_Ray.jpg.preview.jpg</field>
+<field name="originalName">20061004_Eddie_Ray.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">65618</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33556/4/20061004_Eddie_Ray.jpg.preview.jpg</field>
+<field name="checksum">f5c1640107487785f1db2a8e9ba48bf1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061004_ Eddie_Ray.pdf.txt</field>
+<field name="originalName">20061004_ Eddie_Ray.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">37002</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33556/5/20061004_%20Eddie_Ray.pdf.txt</field>
+<field name="checksum">4d45d5f0cf2c190b4494cca4f6256406</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061004_Eddie_Ray.jpg</field>
+<field name="originalName">20061004_Eddie_Ray.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">258579</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33556/1/20061004_Eddie_Ray.jpg</field>
+<field name="checksum">f3e0ddb66ae3e451ba0cff64317b552c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20061004_ Eddie_Ray.pdf</field>
+<field name="originalName">20061004_ Eddie_Ray.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">310779</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33556/2/20061004_%20Eddie_Ray.pdf</field>
+<field name="checksum">c9355de6503d8d83a3d92948ff363163</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33556</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33556</field>
+<field name="lastModifyDate">2018-07-12 13:20:38.447</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33656</identifier><datestamp>2018-07-10T20:44:42Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Horne, Onzie, Jr.</field>
+<field name="value">Cole, Jocelyn</field>
+<field name="value">Jacobs, Daniel</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T20:59:21Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T20:59:21Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2008-06-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33656</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20080617_Onzie_Horne</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Onzie Horne. He discusses his family and the extensive musical background of his father, Onzie Horne, Sr, who wrote arrangements for Stax and Sun studios. He also describes attending Carleton College, and then his subsequent decision to return to Memphis in order to work as an activist. While in Memphis he participated in sit-ins, marches, and was close friends with members of the Invaders.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="none">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278568587</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Music</field>
+<field name="value">Stax Records</field>
+<field name="value">Sun Records</field>
+<field name="value">Carleton College (Northfield, Minn.)</field>
+<field name="value">The Invaders</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Race relations</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Onzie Horne, 2008</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080617_Onzie_Horne.JPG</field>
+<field name="originalName">20080617_Onzie_Horne.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">100027</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33656/1/20080617_Onzie_Horne.JPG</field>
+<field name="checksum">b476c928a4f4d34ad53612aeaa7fe45d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20080617_Onzie_Horne.pdf</field>
+<field name="originalName">20080617_Onzie_Horne.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">402069</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33656/2/20080617_Onzie_Horne.pdf</field>
+<field name="checksum">038c85557ee91ab562d1c9d682cf0b15</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080617_Onzie_Horne.JPG.jpg</field>
+<field name="originalName">20080617_Onzie_Horne.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11736</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33656/3/20080617_Onzie_Horne.JPG.jpg</field>
+<field name="checksum">c7ccaae29bbdebf77862f9223387de03</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20080617_Onzie_Horne.pdf.jpg</field>
+<field name="originalName">20080617_Onzie_Horne.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8971</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33656/6/20080617_Onzie_Horne.pdf.jpg</field>
+<field name="checksum">b44d4fb439697a7f474a01e1b2d204be</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080617_Onzie_Horne.JPG.preview.jpg</field>
+<field name="originalName">20080617_Onzie_Horne.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">46076</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33656/4/20080617_Onzie_Horne.JPG.preview.jpg</field>
+<field name="checksum">d9796ba12830d3cebe6c30f0d53097e8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080617_Onzie_Horne.pdf.txt</field>
+<field name="originalName">20080617_Onzie_Horne.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">69853</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33656/5/20080617_Onzie_Horne.pdf.txt</field>
+<field name="checksum">52d3fc59b5952206f142f5fe20a066d8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33656</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33656</field>
+<field name="lastModifyDate">2018-07-10 15:44:42.842</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/34007</identifier><datestamp>2018-09-10T17:07:26Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Boles, Raymond</field>
+<field name="value">Wigginton, Russell Thomas</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-09-04T14:04:14Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-09-04T14:04:14Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-11-16</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/34007</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20071116_Boles_Raymond</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">An audio interview conducted by StoryCorps at Rhodes College in which Dr. Russell Wigginton interviews Mr. Raymond Boles who has been working at Rhodes for 46 years. Mr. Boles talks about his life on a farm and how that's affected him today. He also speaks about his interaction with Rhodes students and how personable he was.</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/289116818</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="none">
+<field name="value">Rhodes College</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">StoryCorps</field>
+<field name="value">Farms</field>
+<field name="value">African Americans</field>
+<field name="value">Segregation</field>
+<field name="value">Segregation in education</field>
+</element>
+</element>
+<element name="title">
+<element name="none">
+<field name="value">Raymond Boles and Russ Wigginton, StoryCorps Interview, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Sound</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">RB_tn.JPG.jpg</field>
+<field name="originalName">RB_tn.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10069</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/34007/2/RB_tn.JPG.jpg</field>
+<field name="checksum">ff108dfa4043e16a736bc3170cdbf040</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20071116_Raymond_Boles.pdf.jpg</field>
+<field name="originalName">20071116_Raymond_Boles.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9402</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/34007/6/20071116_Raymond_Boles.pdf.jpg</field>
+<field name="checksum">29f064c41f7bbc38bfe2e78c3660bcde</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">RB_tn.JPG.preview.jpg</field>
+<field name="originalName">RB_tn.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">45190</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/34007/3/RB_tn.JPG.preview.jpg</field>
+<field name="checksum">aeb3f8195535f3d4cf4884657131afe9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">RB_tn.JPG</field>
+<field name="originalName">RB_tn.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">3220099</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/34007/1/RB_tn.JPG</field>
+<field name="checksum">098f963b6e2dcc2cdebc55a03b70e61b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20071116_Raymond_Boles.pdf</field>
+<field name="originalName">20071116_Raymond_Boles.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">96293</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/34007/4/20071116_Raymond_Boles.pdf</field>
+<field name="checksum">e1baf6bc04e89539fb3c674efcbd6d94</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20071116_Raymond_Boles.pdf.txt</field>
+<field name="originalName">20071116_Raymond_Boles.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">34017</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/34007/5/20071116_Raymond_Boles.pdf.txt</field>
+<field name="checksum">79edc3008b176b70a91c0c68de9d6d27</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/34007</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/34007</field>
+<field name="lastModifyDate">2018-09-10 12:07:26.562</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33513</identifier><datestamp>2018-07-12T18:20:38Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Fulton, Walter</field>
+<field name="value">Fulton, Willie Bell</field>
+<field name="value">Mrkva, Andy</field>
+<field name="value">Saba, Daniel</field>
+<field name="value">Saba, Elizabeth</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T16:29:16Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T16:29:16Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2009-06-25</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33513</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20090625_Winnie_Bell_and_Walter_Fulton</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Willie Bell and Walter Fulton, two long time residents of Hyde Park. This interview was a part of the 2009 Crossroads to Freedom Hyde Park team.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278575363</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Hyde Park (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Willie Bell and Walter Fulton, 2009</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090625_Winnie_Bell_and_Walter_Fulton.jpg</field>
+<field name="originalName">20090625_Winnie_Bell_and_Walter_Fulton.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">118830</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33513/1/20090625_Winnie_Bell_and_Walter_Fulton.jpg</field>
+<field name="checksum">b37085b8db2eb70931e8d4f65ba7b789</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20090625_Winnie_Bell_and_Walter_Fulton.pdf</field>
+<field name="originalName">20090625_Winnie_Bell_and_Walter_Fulton.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">226199</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33513/2/20090625_Winnie_Bell_and_Walter_Fulton.pdf</field>
+<field name="checksum">a068708bf94a2d081589a639176faf1e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090625_Winnie_Bell_and_Walter_Fulton.jpg.jpg</field>
+<field name="originalName">20090625_Winnie_Bell_and_Walter_Fulton.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">5943</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33513/3/20090625_Winnie_Bell_and_Walter_Fulton.jpg.jpg</field>
+<field name="checksum">f361d18dc127a090508642cd3058b6a8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20090625_Winnie_Bell_and_Walter_Fulton.pdf.jpg</field>
+<field name="originalName">20090625_Winnie_Bell_and_Walter_Fulton.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12297</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33513/6/20090625_Winnie_Bell_and_Walter_Fulton.pdf.jpg</field>
+<field name="checksum">70f96d25a759eae5e1f63ba0fa1c6670</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090625_Winnie_Bell_and_Walter_Fulton.jpg.preview.jpg</field>
+<field name="originalName">20090625_Winnie_Bell_and_Walter_Fulton.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">21909</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33513/4/20090625_Winnie_Bell_and_Walter_Fulton.jpg.preview.jpg</field>
+<field name="checksum">09280d0d7b14171f934d02a7ffa6e3a5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090625_Winnie_Bell_and_Walter_Fulton.pdf.txt</field>
+<field name="originalName">20090625_Winnie_Bell_and_Walter_Fulton.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">53092</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33513/5/20090625_Winnie_Bell_and_Walter_Fulton.pdf.txt</field>
+<field name="checksum">17d3cc2d248c5103ff9f331559f42215</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33513</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33513</field>
+<field name="lastModifyDate">2018-07-12 13:20:38.559</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33687</identifier><datestamp>2018-07-16T21:03:14Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Brown, Bertha K.</field>
+<field name="value">Zalin, Mackenzie</field>
+<field name="value">Waters, Courtney</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-04T18:01:11Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-04T18:01:11Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2009-07-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33687</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20090730_Bertha_K_Brown</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Bertha (Dixie) K. Brown. She discusses her childhood and upbringing in Boston, Massachusetts. Mrs. Brown talks about the cultural change she experienced once moving to Memphis and the close community of the neighborhood in which she lived.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280262938</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Evergreen Historic District (Memphis, Tenn.)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Bertha "Dixie" Brown, 2009</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090730_Bertha_K_Brown.JPG</field>
+<field name="originalName">20090730_Bertha_K_Brown.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">80901</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33687/1/20090730_Bertha_K_Brown.JPG</field>
+<field name="checksum">217fd167747f2872a22ba24de8c10ce5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20090730_Bertha_K_Brown.pdf</field>
+<field name="originalName">20090730_Bertha_K_Brown.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">194593</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33687/2/20090730_Bertha_K_Brown.pdf</field>
+<field name="checksum">4e03c902fbfea10987d1817dad0b9d68</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090730_Bertha_K_Brown.JPG.jpg</field>
+<field name="originalName">20090730_Bertha_K_Brown.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9466</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33687/3/20090730_Bertha_K_Brown.JPG.jpg</field>
+<field name="checksum">9bd4b5fbfc390f634a3208da68fababf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20090730_Bertha_K_Brown.pdf.jpg</field>
+<field name="originalName">20090730_Bertha_K_Brown.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10065</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33687/6/20090730_Bertha_K_Brown.pdf.jpg</field>
+<field name="checksum">32df5465b866d45ce0e1c456a0bdce7a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090730_Bertha_K_Brown.JPG.preview.jpg</field>
+<field name="originalName">20090730_Bertha_K_Brown.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">37180</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33687/4/20090730_Bertha_K_Brown.JPG.preview.jpg</field>
+<field name="checksum">feeaa0e44b45c80a9c784183e99cfc33</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090730_Bertha_K_Brown.pdf.txt</field>
+<field name="originalName">20090730_Bertha_K_Brown.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">31374</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33687/5/20090730_Bertha_K_Brown.pdf.txt</field>
+<field name="checksum">ee6f869e0851bab961ee7091e010acdf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33687</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33687</field>
+<field name="lastModifyDate">2018-07-16 16:03:14.572</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33489</identifier><datestamp>2018-07-12T18:20:38Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Sugarmon, Russell B., Jr.</field>
+<field name="value">Davis, Francesca</field>
+<field name="value">Holly, James</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T15:23:55Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T15:23:55Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-05-23</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33489</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20070523_Russell_Sugarmon</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Judge Russell B. Sugarmon Jr. is a prominent Memphian who fought to combat racism and establish civil rights during his long lasting legal and political career. During his career, he practiced law in one of the nation's first integrated law firms, was elected to the Tennessee Democratic Party Executive Committee, and two years later ran successfully for the State Senate. He also served as a member of the the NAACP and the ACLU.This interview was conducted in 2007 to be included in the Rhodes College Crossroads to Freedom Digital Archive Project. 2007-05-23</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278553687</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Civil rights</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Law</field>
+<field name="value">Politics</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Russell B. Sugarmon, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070523_Russell_Sugarmon.pdf</field>
+<field name="originalName">20070523_Russell_Sugarmon.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">478614</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33489/1/20070523_Russell_Sugarmon.pdf</field>
+<field name="checksum">c48187b56736b80009b89f0f642bb886</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20070523_Russell_Sugarmon.JPG</field>
+<field name="originalName">20070523_Russell_Sugarmon.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">59982</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33489/2/20070523_Russell_Sugarmon.JPG</field>
+<field name="checksum">fb56ccb83bfa31be539ad6f07f88ea98</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070523_Russell_Sugarmon.pdf.txt</field>
+<field name="originalName">20070523_Russell_Sugarmon.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">80351</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33489/3/20070523_Russell_Sugarmon.pdf.txt</field>
+<field name="checksum">6ba95f19f9b5c3fbfa486958f2bb7788</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070523_Russell_Sugarmon.pdf.jpg</field>
+<field name="originalName">20070523_Russell_Sugarmon.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10303</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33489/4/20070523_Russell_Sugarmon.pdf.jpg</field>
+<field name="checksum">58c4ccb671cf7eca65bc5c9298be2ca2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20070523_Russell_Sugarmon.JPG.jpg</field>
+<field name="originalName">20070523_Russell_Sugarmon.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13521</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33489/5/20070523_Russell_Sugarmon.JPG.jpg</field>
+<field name="checksum">350bd79a9226f4c22f548b2d95821a8d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070523_Russell_Sugarmon.JPG.preview.jpg</field>
+<field name="originalName">20070523_Russell_Sugarmon.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">41092</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33489/6/20070523_Russell_Sugarmon.JPG.preview.jpg</field>
+<field name="checksum">bf152a152f1e16ceacb66e11f611d0b9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33489</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33489</field>
+<field name="lastModifyDate">2018-07-12 13:20:38.644</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33589</identifier><datestamp>2018-07-26T18:51:53Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Madden, Mary</field>
+<field name="value">Rhynes, Anne</field>
+<field name="value">Strauser, Matt</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-23T18:43:19Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-23T18:43:19Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2011-06-23</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33589</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20110623_Mary_Madden</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Mary Madden. She discusses race, religion, and music in the city of Memphis. From the Crossroads to Freedom digital archive.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/281661543</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Religion</field>
+<field name="value">Music</field>
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Race relations</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Mary Madden, 2011</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110623_Mary_Madden.PNG.jpg</field>
+<field name="originalName">20110623_Mary_Madden.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">16940</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33589/3/20110623_Mary_Madden.PNG.jpg</field>
+<field name="checksum">f47464b695bb4d182d6c43c68bbdf39e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20110623_Mary_Madden.pdf.jpg</field>
+<field name="originalName">20110623_Mary_Madden.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11911</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33589/6/20110623_Mary_Madden.pdf.jpg</field>
+<field name="checksum">3767c586078b402985c44161cdbe6523</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110623_Mary_Madden.PNG.preview.jpg</field>
+<field name="originalName">20110623_Mary_Madden.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">65195</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33589/4/20110623_Mary_Madden.PNG.preview.jpg</field>
+<field name="checksum">e137500563a3667caacd4e3271f311d5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110623_Mary_Madden.pdf.txt</field>
+<field name="originalName">20110623_Mary_Madden.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">25534</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33589/5/20110623_Mary_Madden.pdf.txt</field>
+<field name="checksum">8898b13270329aee7a030bae261840c5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110623_Mary_Madden.PNG</field>
+<field name="originalName">20110623_Mary_Madden.PNG</field>
+<field name="format">image/png</field>
+<field name="size">2349613</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33589/1/20110623_Mary_Madden.PNG</field>
+<field name="checksum">327e0e7fbf54a6e9c34d0b42cb8511ca</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20110623_Mary_Madden.pdf</field>
+<field name="originalName">20110623_Mary_Madden.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">174712</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33589/2/20110623_Mary_Madden.pdf</field>
+<field name="checksum">e48a8ce71d783c1444e1438a494ce0d9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33589</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33589</field>
+<field name="lastModifyDate">2018-07-26 13:51:53.531</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33608</identifier><datestamp>2018-07-17T17:28:42Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Washington, Bernard</field>
+<field name="value">McCain Tretarius</field>
+<field name="value">Jones, Cameron</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:18Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:18Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-07-10</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33608</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130710_Bernard_Washington</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Bernard Washington. Washington is a member of Greater White Stone Missionary Baptist Church, located in South Memphis. Washington also works in accounting.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280401111</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Bernard Washington, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130710_Bernard_Washington.JPG</field>
+<field name="originalName">20130710_Bernard_Washington.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">48499</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33608/1/20130710_Bernard_Washington.JPG</field>
+<field name="checksum">b53e79e96316ce9e6bed10ecab0ec073</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130710_Bernard_Washington.pdf</field>
+<field name="originalName">20130710_Bernard_Washington.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">175589</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33608/2/20130710_Bernard_Washington.pdf</field>
+<field name="checksum">eee304dfc676941572ae44725813c18f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130710_Bernard_Washington.JPG.jpg</field>
+<field name="originalName">20130710_Bernard_Washington.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6130</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33608/3/20130710_Bernard_Washington.JPG.jpg</field>
+<field name="checksum">c42e010c9f1dcc558cf5d295c23db6a5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130710_Bernard_Washington.pdf.jpg</field>
+<field name="originalName">20130710_Bernard_Washington.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11738</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33608/6/20130710_Bernard_Washington.pdf.jpg</field>
+<field name="checksum">b5223314c8a67c8b836a8c1d7832fd5d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130710_Bernard_Washington.JPG.preview.jpg</field>
+<field name="originalName">20130710_Bernard_Washington.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">21868</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33608/4/20130710_Bernard_Washington.JPG.preview.jpg</field>
+<field name="checksum">f0d89e0ccf8ad7aa80a08e31606a2d43</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130710_Bernard_Washington.pdf.txt</field>
+<field name="originalName">20130710_Bernard_Washington.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">27399</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33608/5/20130710_Bernard_Washington.pdf.txt</field>
+<field name="checksum">e2a09fd2ca70d31c4b392b6a2546dee7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33608</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33608</field>
+<field name="lastModifyDate">2018-07-17 12:28:42.934</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33732</identifier><datestamp>2018-08-02T20:04:46Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Bond, Noah</field>
+<field name="value">Harpole, Zachary (Zach)</field>
+<field name="value">Hicks, Grace M.</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-20T21:27:13Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-20T21:27:13Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2012-06-26</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33732</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20120626_Noah_Bond</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Noah Bond. He is a retired school teacher. He taught during the 70's in Memphis, Tennessee. He shares his story of dealing with "separate but equal" and the integration of Memphis City Schools.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/282877349</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Segregation</field>
+<field name="value">Education</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Noah Bond, 2012</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20120626_Noah_Bond.JPG</field>
+<field name="originalName">20120626_Noah_Bond.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">72705</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33732/1/20120626_Noah_Bond.JPG</field>
+<field name="checksum">fd2fe57f6279549dc5f3afd84eb237d9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20120626_Noah_Bond.pdf</field>
+<field name="originalName">20120626_Noah_Bond.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">264041</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33732/2/20120626_Noah_Bond.pdf</field>
+<field name="checksum">113b5f8091e7a7562acb64272b5bca18</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20120626_Noah_Bond.JPG.jpg</field>
+<field name="originalName">20120626_Noah_Bond.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8044</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33732/3/20120626_Noah_Bond.JPG.jpg</field>
+<field name="checksum">13ef01588a0681e720c866983a151121</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20120626_Noah_Bond.pdf.jpg</field>
+<field name="originalName">20120626_Noah_Bond.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9311</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33732/6/20120626_Noah_Bond.pdf.jpg</field>
+<field name="checksum">a42f083e0415f1a71e53660fd1e565dd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20120626_Noah_Bond.JPG.preview.jpg</field>
+<field name="originalName">20120626_Noah_Bond.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">32455</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33732/4/20120626_Noah_Bond.JPG.preview.jpg</field>
+<field name="checksum">943f63efc728fec5d680ec4b83cf0b65</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20120626_Noah_Bond.pdf.txt</field>
+<field name="originalName">20120626_Noah_Bond.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">40780</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33732/5/20120626_Noah_Bond.pdf.txt</field>
+<field name="checksum">8ef9769182908332959ea03d444ebe8a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33732</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33732</field>
+<field name="lastModifyDate">2018-08-02 15:04:46.228</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33616</identifier><datestamp>2018-07-17T18:06:53Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Moore, Lou Emma</field>
+<field name="value">Boone, Damesha</field>
+<field name="value">Miller, Rodtavis</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:20Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:20Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-06-04</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33616</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140604_Lou_Emma_Moore</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview Lou Emma Moore discusses life in Mississippi, the importance of church, and gaining independence in Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280409023</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+<field name="value">Mississippi</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Lou Emma Moore, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140604_Lou_Emma_Moore.JPG</field>
+<field name="originalName">20140604_Lou_Emma_Moore.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">69660</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33616/1/20140604_Lou_Emma_Moore.JPG</field>
+<field name="checksum">250fd315bd550a250b5ca9af4faac755</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140604_Lou_Emma_Moore.pdf</field>
+<field name="originalName">20140604_Lou_Emma_Moore.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">69093</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33616/2/20140604_Lou_Emma_Moore.pdf</field>
+<field name="checksum">8cc5c1feb55289fabf14e2bd714e5050</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140604_Lou_Emma_Moore.JPG.jpg</field>
+<field name="originalName">20140604_Lou_Emma_Moore.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7851</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33616/3/20140604_Lou_Emma_Moore.JPG.jpg</field>
+<field name="checksum">58b4506661ca721b3261912d46f40740</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140604_Lou_Emma_Moore.pdf.jpg</field>
+<field name="originalName">20140604_Lou_Emma_Moore.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12462</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33616/6/20140604_Lou_Emma_Moore.pdf.jpg</field>
+<field name="checksum">366809b5d6d798cd77fbbcecae3f2555</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140604_Lou_Emma_Moore.JPG.preview.jpg</field>
+<field name="originalName">20140604_Lou_Emma_Moore.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">32646</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33616/4/20140604_Lou_Emma_Moore.JPG.preview.jpg</field>
+<field name="checksum">9f767b353030dc8f08bb0a451458e048</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140604_Lou_Emma_Moore.pdf.txt</field>
+<field name="originalName">20140604_Lou_Emma_Moore.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8931</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33616/5/20140604_Lou_Emma_Moore.pdf.txt</field>
+<field name="checksum">21adfa35a197267df0c8ce589cb0393d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33616</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33616</field>
+<field name="lastModifyDate">2018-07-17 13:06:53.025</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33510</identifier><datestamp>2018-07-16T20:36:29Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Lapides, George</field>
+<field name="value">Jacobs, Daniel</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T15:24:01Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T15:24:01Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-10-22</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33510</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20071022_George_Lapides</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with George Lapides, a sports journalist and native Memphian who began his&#xd;
+journalism career covering politics in the Memphis tri-state area. Inspired by the editor of the Press Scimitar and&#xd;
+Commercial Appeal to go into journalism, he explains the experiences that accompanied his move into sports&#xd;
+journalism and the stories he covered during the Civil Rights era.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280258230</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Civil rights</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Sports</field>
+<field name="value">Race relations</field>
+<field name="value">Kennedy, Robert F., 1925-1968</field>
+<field name="value">Memphis State University</field>
+<field name="value">Baseketball</field>
+<field name="value">Newspapers</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">George Lapides, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20071022_George_Lapides.pdf</field>
+<field name="originalName">20071022_George_Lapides.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">430365</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33510/1/20071022_George_Lapides.pdf</field>
+<field name="checksum">e6894ed0d7e4e97192ba9713144c036c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20071022_George_Lapides.JPG</field>
+<field name="originalName">20071022_George_Lapides.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">70070</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33510/2/20071022_George_Lapides.JPG</field>
+<field name="checksum">7c2cb98faf9af78336ffd9d6bd54d33d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20071022_George_Lapides.pdf.txt</field>
+<field name="originalName">20071022_George_Lapides.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">47493</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33510/3/20071022_George_Lapides.pdf.txt</field>
+<field name="checksum">ea980114f8b3c9428bef6c832ab06944</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20071022_George_Lapides.pdf.jpg</field>
+<field name="originalName">20071022_George_Lapides.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9155</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33510/4/20071022_George_Lapides.pdf.jpg</field>
+<field name="checksum">c64d8c298a38e53a2c123f3dcc13c745</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20071022_George_Lapides.JPG.jpg</field>
+<field name="originalName">20071022_George_Lapides.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">15774</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33510/5/20071022_George_Lapides.JPG.jpg</field>
+<field name="checksum">4c8ec34a81ffdb732edb8d64e373b1d5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20071022_George_Lapides.JPG.preview.jpg</field>
+<field name="originalName">20071022_George_Lapides.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">48312</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33510/6/20071022_George_Lapides.JPG.preview.jpg</field>
+<field name="checksum">8a2ad1d1d90a59b2d77a29e53e7e507a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33510</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33510</field>
+<field name="lastModifyDate">2018-07-16 15:36:29.862</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33703</identifier><datestamp>2018-07-17T19:08:49Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Lockwood, Steve</field>
+<field name="value">Bryant, Madalyn</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-12T15:31:00Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-12T15:31:00Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2017-07-03</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33703</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20170703_Steve_Lockwood</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, Steve Lockwood talks about his past experiences and his time at the Frayser Community Development Corporation. Interviewer Madalyn Bryant ('17).</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278585632</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Education</field>
+<field name="value">Frayser (Memphis, Tenn.)</field>
+<field name="value">Community Development Corporation</field>
+<field name="value">Class of 2017</field>
+<field name="value">2017 Summer</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Steve Lockwood, 2017</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170703_Steve_Lockwood.JPG.jpg</field>
+<field name="originalName">20170703_Steve_Lockwood.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10509</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33703/2/20170703_Steve_Lockwood.JPG.jpg</field>
+<field name="checksum">aa27dffd08277384d023d667c7c9fb43</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20170703_Steve_Lockwood.pdf.jpg</field>
+<field name="originalName">20170703_Steve_Lockwood.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10109</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33703/6/20170703_Steve_Lockwood.pdf.jpg</field>
+<field name="checksum">71c5c72c10aa2749be51521ef8dbd1de</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170703_Steve_Lockwood.JPG.preview.jpg</field>
+<field name="originalName">20170703_Steve_Lockwood.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">38644</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33703/3/20170703_Steve_Lockwood.JPG.preview.jpg</field>
+<field name="checksum">10147dd48fb7b9f2b32dcc524ad58472</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170703_Steve_Lockwood.pdf.txt</field>
+<field name="originalName">20170703_Steve_Lockwood.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">52245</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33703/5/20170703_Steve_Lockwood.pdf.txt</field>
+<field name="checksum">836dba9faf0068b0f9e69d0a588995a9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170703_Steve_Lockwood.JPG</field>
+<field name="originalName">20170703_Steve_Lockwood.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">86886</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33703/1/20170703_Steve_Lockwood.JPG</field>
+<field name="checksum">a4f5770f92e306d5c0c108f93a43332d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20170703_Steve_Lockwood.pdf</field>
+<field name="originalName">20170703_Steve_Lockwood.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">172426</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33703/4/20170703_Steve_Lockwood.pdf</field>
+<field name="checksum">057d4a837c5464631cd448cdbb06ceee</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33703</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33703</field>
+<field name="lastModifyDate">2018-07-17 14:08:49.94</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33526</identifier><datestamp>2018-07-27T19:22:09Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Bolden, Maggie</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T16:29:20Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T16:29:20Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2009-07-21</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33526</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20090721_Maggie_Bolden</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Maggie Bolden. She describes her life experiences in Memphis and elsewhere. She especially describes the differences between Memphis and other places that she has lived.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278578027</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Hyde Park (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Civil rights</field>
+<field name="value">Education</field>
+<field name="value">Military</field>
+<field name="value">Memphis City Schools</field>
+<field name="value">Integration</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Maggie Bolden, 2009</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090721_Maggie_Bolden.PNG</field>
+<field name="originalName">20090721_Maggie_Bolden.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1845475</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33526/1/20090721_Maggie_Bolden.PNG</field>
+<field name="checksum">a303d6a92e9a83f83ec8d04c9ffaeeca</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20090721_Maggie_Bolden.pdf</field>
+<field name="originalName">20090721_Maggie_Bolden.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">251430</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33526/2/20090721_Maggie_Bolden.pdf</field>
+<field name="checksum">28a2ebce95a45aa10cebb726293a08dc</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090721_Maggie_Bolden.PNG.jpg</field>
+<field name="originalName">20090721_Maggie_Bolden.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9284</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33526/3/20090721_Maggie_Bolden.PNG.jpg</field>
+<field name="checksum">571974779bd2223f4d1d5b2d89ef38a4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20090721_Maggie_Bolden.pdf.jpg</field>
+<field name="originalName">20090721_Maggie_Bolden.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11587</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33526/6/20090721_Maggie_Bolden.pdf.jpg</field>
+<field name="checksum">35b9effa2a7703a46b7f918764ba8642</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090721_Maggie_Bolden.PNG.preview.jpg</field>
+<field name="originalName">20090721_Maggie_Bolden.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">36969</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33526/4/20090721_Maggie_Bolden.PNG.preview.jpg</field>
+<field name="checksum">64b532035559e45a6394c14d8aa6bf9b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090721_Maggie_Bolden.pdf.txt</field>
+<field name="originalName">20090721_Maggie_Bolden.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">66292</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33526/5/20090721_Maggie_Bolden.pdf.txt</field>
+<field name="checksum">a6c30fe24e54350670b9e1eede36988e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33526</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33526</field>
+<field name="lastModifyDate">2018-07-27 14:22:09.752</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33377</identifier><datestamp>2018-07-17T19:21:11Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Cook, Wayne</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:36Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:36Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-06-25</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33377</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140625_Wayne_Cook</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Wayne Cook shares his experience growing up and living in the Highland Heights neighborhood in Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280420260</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Wayne Cook, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140625_Wayne_Cook.PNG</field>
+<field name="originalName">20140625_Wayne_Cook.PNG</field>
+<field name="format">image/png</field>
+<field name="size">204773</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33377/1/20140625_Wayne_Cook.PNG</field>
+<field name="checksum">eda32cfe32b04c2a5fb6b1f6171008f5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140625_Wayne_Cook.pdf</field>
+<field name="originalName">20140625_Wayne_Cook.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">136957</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33377/2/20140625_Wayne_Cook.pdf</field>
+<field name="checksum">9aeaaecd4401ebace7d00550a6b4a96d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140625_Wayne_Cook.PNG.jpg</field>
+<field name="originalName">20140625_Wayne_Cook.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8752</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33377/3/20140625_Wayne_Cook.PNG.jpg</field>
+<field name="checksum">02055f82e9ceae999f6a7c5c664704aa</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140625_Wayne_Cook.pdf.jpg</field>
+<field name="originalName">20140625_Wayne_Cook.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12255</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33377/6/20140625_Wayne_Cook.pdf.jpg</field>
+<field name="checksum">42330c8948eb170de77f6d8391bf2f85</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140625_Wayne_Cook.PNG.preview.jpg</field>
+<field name="originalName">20140625_Wayne_Cook.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">10308</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33377/4/20140625_Wayne_Cook.PNG.preview.jpg</field>
+<field name="checksum">e42bf547f52f769cf8eb3ad2c617b1fb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140625_Wayne_Cook.pdf.txt</field>
+<field name="originalName">20140625_Wayne_Cook.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">12412</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33377/5/20140625_Wayne_Cook.pdf.txt</field>
+<field name="checksum">d43ff16d218ae57497d071a35af4d93a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33377</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33377</field>
+<field name="lastModifyDate">2018-07-17 14:21:11.206</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33496</identifier><datestamp>2018-07-27T16:33:42Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Hailey, Ed</field>
+<field name="value">Hassan, Khadija</field>
+<field name="value">Davis, Francesca</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T15:23:57Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T15:23:57Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-07-25</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33496</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20070725_Ed_Hailey</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Edward Hailey, who was born and raised in Memphis and experienced the city's race relations throughout the decades. He worked his entire life in manufacturing, and discusses race through the day to day perspective of having worked with an integrated work force.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278556826</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Civil rights</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Crump, Edward Hull, 1874-1954</field>
+<field name="value">Integration</field>
+<field name="value">Race relations</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Edward Hailey, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070725_Ed_Hailey.JPG</field>
+<field name="originalName">20070725_Ed_Hailey.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">62678</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33496/1/20070725_Ed_Hailey.JPG</field>
+<field name="checksum">98ea45bc8c93a5b4439c3ebbc8dd8088</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20070725_Ed_Hailey.pdf</field>
+<field name="originalName">20070725_Ed_Hailey.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">501676</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33496/2/20070725_Ed_Hailey.pdf</field>
+<field name="checksum">3e79b18d1eebb2a0c0aaeb4b9bb46bcb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070725_Ed_Hailey.JPG.jpg</field>
+<field name="originalName">20070725_Ed_Hailey.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13143</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33496/3/20070725_Ed_Hailey.JPG.jpg</field>
+<field name="checksum">8551d3f1927be4a536a28769eef5cbda</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20070725_Ed_Hailey.pdf.jpg</field>
+<field name="originalName">20070725_Ed_Hailey.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10718</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33496/6/20070725_Ed_Hailey.pdf.jpg</field>
+<field name="checksum">48b1f953e709edd4e5014a5db57d805e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070725_Ed_Hailey.JPG.preview.jpg</field>
+<field name="originalName">20070725_Ed_Hailey.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">43706</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33496/4/20070725_Ed_Hailey.JPG.preview.jpg</field>
+<field name="checksum">40e5839299d9431ed5b9f58192ab661f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070725_Ed_Hailey.pdf.txt</field>
+<field name="originalName">20070725_Ed_Hailey.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">35975</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33496/5/20070725_Ed_Hailey.pdf.txt</field>
+<field name="checksum">1b4fff656fcc64e0bfb3a82c6f81cb95</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33496</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33496</field>
+<field name="lastModifyDate">2018-07-27 11:33:42.076</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/34254</identifier><datestamp>2018-09-21T15:16:41Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="author">
+<element name="none">
+<field name="value">Bowman, Rob</field>
+</element>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-09-21T15:15:04Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-09-21T15:15:04Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2003-02-13</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/34254</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="sponsorship">
+<element name="en_US">
+<field name="value">Stax musician Rob Bowman discusses his career, other Stax musicians including Booker T., Isaac Hayes, and Otis Redding, the Blues genre at Stax, and black culture as it relates to music. Interview recorded on February 13th, 2003.</field>
+</element>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/291122938</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Stax Records</field>
+<field name="value">Music</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Rob Bowman, 2003</field>
+</element>
+</element>
+<element name="type">
+<element name="en_US">
+<field name="value">Video</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">2003_Rob_Bowman.JPG</field>
+<field name="originalName">2003_Rob_Bowman.JPG</field>
+<field name="description"/>
+<field name="format">image/jpeg</field>
+<field name="size">91959</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/34254/1/2003_Rob_Bowman.JPG</field>
+<field name="checksum">c464da5de41a2f90cca11ae384a0069c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">2003_Rob_Bowman.JPG.jpg</field>
+<field name="originalName">2003_Rob_Bowman.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11115</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/34254/3/2003_Rob_Bowman.JPG.jpg</field>
+<field name="checksum">4fdf4560c821e54c984b626bf435a492</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">2003_Rob_Bowman.JPG.preview.jpg</field>
+<field name="originalName">2003_Rob_Bowman.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">42113</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/34254/4/2003_Rob_Bowman.JPG.preview.jpg</field>
+<field name="checksum">28d4cdea3bf45930e49f7d2b7dff31f5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">LICENSE</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">license.txt</field>
+<field name="originalName">license.txt</field>
+<field name="format">text/plain</field>
+<field name="size">1663</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/34254/2/license.txt</field>
+<field name="checksum">69d7879d0c65ae9be06d38a27d11bcb2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/34254</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/34254</field>
+<field name="lastModifyDate">2018-09-21 10:16:41.109</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+<element name="license">
+<field name="bin">Tk9OLUVYQ0xVU0lWRSBESVNUUklCVVRJT04gTElDRU5TRQoKQnkgc2lnbmluZyBhbmQgc3VibWl0dGluZyB0aGlzIGxpY2Vuc2UsIHlvdSAodGhlIGF1dGhvcihzKSBvciBjb3B5cmlnaHQKb3duZXIpIGdyYW50cyB0byBSaG9kZXMgQ29sbGVnZSAoUkhPREVTKSB0aGUgbm9uLWV4Y2x1c2l2ZSByaWdodCB0byByZXByb2R1Y2UsCnRyYW5zbGF0ZSAoYXMgZGVmaW5lZCBiZWxvdyksIGFuZC9vciBkaXN0cmlidXRlIHlvdXIgc3VibWlzc2lvbiAoaW5jbHVkaW5nCnRoZSBhYnN0cmFjdCkgd29ybGR3aWRlIGluIHByaW50IGFuZCBlbGVjdHJvbmljIGZvcm1hdCBhbmQgaW4gYW55IG1lZGl1bSwKaW5jbHVkaW5nIGJ1dCBub3QgbGltaXRlZCB0byBhdWRpbyBvciB2aWRlby4KCllvdSBhZ3JlZSB0aGF0IFJIT0RFUyBtYXksIHdpdGhvdXQgY2hhbmdpbmcgdGhlIGNvbnRlbnQsIHRyYW5zbGF0ZSB0aGUKc3VibWlzc2lvbiB0byBhbnkgbWVkaXVtIG9yIGZvcm1hdCBmb3IgdGhlIHB1cnBvc2Ugb2YgcHJlc2VydmF0aW9uLgoKWW91IGFsc28gYWdyZWUgdGhhdCBSSE9ERVMgbWF5IGtlZXAgbW9yZSB0aGFuIG9uZSBjb3B5IG9mIHRoaXMgc3VibWlzc2lvbiBmb3IKcHVycG9zZXMgb2Ygc2VjdXJpdHksIGJhY2stdXAgYW5kIHByZXNlcnZhdGlvbi4KCllvdSByZXByZXNlbnQgdGhhdCB0aGUgc3VibWlzc2lvbiBpcyB5b3VyIG9yaWdpbmFsIHdvcmssIGFuZCB0aGF0IHlvdSBoYXZlCnRoZSByaWdodCB0byBncmFudCB0aGUgcmlnaHRzIGNvbnRhaW5lZCBpbiB0aGlzIGxpY2Vuc2UuIFlvdSBhbHNvIHJlcHJlc2VudAp0aGF0IHlvdXIgc3VibWlzc2lvbiBkb2VzIG5vdCwgdG8gdGhlIGJlc3Qgb2YgeW91ciBrbm93bGVkZ2UsIGluZnJpbmdlIHVwb24KYW55b25lJ3MgY29weXJpZ2h0LgoKSWYgdGhlIHN1Ym1pc3Npb24gY29udGFpbnMgbWF0ZXJpYWwgZm9yIHdoaWNoIHlvdSBkbyBub3QgaG9sZCBjb3B5cmlnaHQsCnlvdSByZXByZXNlbnQgdGhhdCB5b3UgaGF2ZSBvYnRhaW5lZCB0aGUgdW5yZXN0cmljdGVkIHBlcm1pc3Npb24gb2YgdGhlCmNvcHlyaWdodCBvd25lciB0byBncmFudCBSSE9ERVMgdGhlIHJpZ2h0cyByZXF1aXJlZCBieSB0aGlzIGxpY2Vuc2UsIGFuZCB0aGF0CnN1Y2ggdGhpcmQtcGFydHkgb3duZWQgbWF0ZXJpYWwgaXMgY2xlYXJseSBpZGVudGlmaWVkIGFuZCBhY2tub3dsZWRnZWQKd2l0aGluIHRoZSB0ZXh0IG9yIGNvbnRlbnQgb2YgdGhlIHN1Ym1pc3Npb24uCgpJRiBUSEUgU1VCTUlTU0lPTiBJUyBCQVNFRCBVUE9OIFdPUksgVEhBVCBIQVMgQkVFTiBTUE9OU09SRUQgT1IgU1VQUE9SVEVECkJZIEFOIEFHRU5DWSBPUiBPUkdBTklaQVRJT04gT1RIRVIgVEhBTiBSSE9ERVMsIFlPVSBSRVBSRVNFTlQgVEhBVCBZT1UgSEFWRQpGVUxGSUxMRUQgQU5ZIFJJR0hUIE9GIFJFVklFVyBPUiBPVEhFUiBPQkxJR0FUSU9OUyBSRVFVSVJFRCBCWSBTVUNICkNPTlRSQUNUIE9SIEFHUkVFTUVOVC4KClJIT0RFUyB3aWxsIGNsZWFybHkgaWRlbnRpZnkgeW91ciBuYW1lKHMpIGFzIHRoZSBhdXRob3Iocykgb3Igb3duZXIocykgb2YgdGhlCnN1Ym1pc3Npb24sIGFuZCB3aWxsIG5vdCBtYWtlIGFueSBhbHRlcmF0aW9uLCBvdGhlciB0aGFuIGFzIGFsbG93ZWQgYnkgdGhpcwpsaWNlbnNlLCB0byB5b3VyIHN1Ym1pc3Npb24uCg==</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33670</identifier><datestamp>2018-07-26T23:13:36Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Tyler, Marshall</field>
+<field name="value">Scales, Marrissa</field>
+<field name="value">Jacobs, Daniel</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T20:59:24Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T20:59:24Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2008-07-31</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33670</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20080731_Marshall_Tyler</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Marshall Tyler. In the interview he talks about growing up in Lexington and serving in the Tennessee Army National Guard. As a private in the National Guard Tyler was mobilized twice in 1968 to go to Memphis. In the interview he describes his experience in Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="none">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278573496</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Segregation</field>
+<field name="value">Race relations</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Marshall Tyler, 2008</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080731_Marshall_Tyler.JPG</field>
+<field name="originalName">20080731_Marshall_Tyler.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">57384</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33670/1/20080731_Marshall_Tyler.JPG</field>
+<field name="checksum">28c38cb8fc4e47472284692e946792b6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20080731_Marshall_Tyler.pdf</field>
+<field name="originalName">20080731_Marshall_Tyler.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">311792</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33670/2/20080731_Marshall_Tyler.pdf</field>
+<field name="checksum">448b4881e1bd6eea24fc1b25ca80ff65</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080731_Marshall_Tyler.JPG.jpg</field>
+<field name="originalName">20080731_Marshall_Tyler.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7306</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33670/3/20080731_Marshall_Tyler.JPG.jpg</field>
+<field name="checksum">1194a97a1bf1c4062df221cef18de0df</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20080731_Marshall_Tyler.pdf.jpg</field>
+<field name="originalName">20080731_Marshall_Tyler.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8920</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33670/6/20080731_Marshall_Tyler.pdf.jpg</field>
+<field name="checksum">9eb8775ad03dda8e549e089d1fad7619</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080731_Marshall_Tyler.JPG.preview.jpg</field>
+<field name="originalName">20080731_Marshall_Tyler.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">26392</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33670/4/20080731_Marshall_Tyler.JPG.preview.jpg</field>
+<field name="checksum">ca3a7cc46dc1388d476846bc7809ff24</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080731_Marshall_Tyler.pdf.txt</field>
+<field name="originalName">20080731_Marshall_Tyler.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">31396</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33670/5/20080731_Marshall_Tyler.pdf.txt</field>
+<field name="checksum">c23aa5bd717cea088e3943aa378bed3c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33670</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33670</field>
+<field name="lastModifyDate">2018-07-26 18:13:36.931</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33734</identifier><datestamp>2018-07-17T16:48:31Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Thigpen, Henderson</field>
+<field name="value">Kollath, Jeff</field>
+<field name="value">Hughes, Charles L.</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-20T21:27:13Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-20T21:27:13Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2017-08-01</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33734</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20170801_Henderson_Thigpen</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Henderson Thigpen discusses his early life writing poetry for church and how that led to him being hired as a songwriter for Stax records.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278586340</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Stax Records</field>
+<field name="value">Music</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Henderson Thigpen, 2017</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170801_Henderson_Thigpen.JPG</field>
+<field name="originalName">20170801_Henderson_Thigpen.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">52099</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33734/1/20170801_Henderson_Thigpen.JPG</field>
+<field name="checksum">c22f93ec3a285c3a93094cb1f6e27458</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20170801_Henderson_Thigpen.pdf</field>
+<field name="originalName">20170801_Henderson_Thigpen.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">303681</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33734/2/20170801_Henderson_Thigpen.pdf</field>
+<field name="checksum">b0926784e13cc4d4dc8c946bcfd8120d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170801_Henderson_Thigpen.JPG.jpg</field>
+<field name="originalName">20170801_Henderson_Thigpen.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6018</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33734/3/20170801_Henderson_Thigpen.JPG.jpg</field>
+<field name="checksum">74961cc83ed90fcf90127451675bec49</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20170801_Henderson_Thigpen.pdf.jpg</field>
+<field name="originalName">20170801_Henderson_Thigpen.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13578</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33734/6/20170801_Henderson_Thigpen.pdf.jpg</field>
+<field name="checksum">e5dd652d0158e525dd20d794ca13ba0b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170801_Henderson_Thigpen.JPG.preview.jpg</field>
+<field name="originalName">20170801_Henderson_Thigpen.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">22764</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33734/4/20170801_Henderson_Thigpen.JPG.preview.jpg</field>
+<field name="checksum">b7bc89473b733be833edde0c1a26eba6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170801_Henderson_Thigpen.pdf.txt</field>
+<field name="originalName">20170801_Henderson_Thigpen.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">63973</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33734/5/20170801_Henderson_Thigpen.pdf.txt</field>
+<field name="checksum">cef4fc90eb0220eeacb25b5ab8a1a846</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33734</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33734</field>
+<field name="lastModifyDate">2018-07-17 11:48:31.634</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33736</identifier><datestamp>2018-07-17T16:47:33Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Axton, Estelle</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-20T21:27:14Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-20T21:27:14Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">1975-00-00</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33736</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">1975_Estelle_Axton</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, Estelle Axton describes her musical career and the role of the Stax Museum in her Memphis music experience.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279474818</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Stax Records</field>
+<field name="value">Music</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Estelle Axton, 1975</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">19750000_Estelle_Axton.JPG</field>
+<field name="originalName">19750000_Estelle_Axton.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">44985</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33736/1/19750000_Estelle_Axton.JPG</field>
+<field name="checksum">6c4f745f678854e4dcc575be309f4dd8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">19750000_Estelle_Axton.txt</field>
+<field name="originalName">19750000_Estelle_Axton.txt</field>
+<field name="format">text/plain</field>
+<field name="size">79656</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33736/2/19750000_Estelle_Axton.txt</field>
+<field name="checksum">5c5b983ac2b386915a28e5fb27465123</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">19750000_Estelle_Axton.JPG.jpg</field>
+<field name="originalName">19750000_Estelle_Axton.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">5501</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33736/3/19750000_Estelle_Axton.JPG.jpg</field>
+<field name="checksum">fa34008ecf8af296efe3d28cff0ac3d6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">19750000_Estelle_Axton.JPG.preview.jpg</field>
+<field name="originalName">19750000_Estelle_Axton.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">17534</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33736/4/19750000_Estelle_Axton.JPG.preview.jpg</field>
+<field name="checksum">f465beef5fb5f9e56bd631cc21d86e25</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">19750000_Estelle_Axton.txt.txt</field>
+<field name="originalName">19750000_Estelle_Axton.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">74196</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33736/5/19750000_Estelle_Axton.txt.txt</field>
+<field name="checksum">f4ef956fd490c8e6262cea4fdf6b4a90</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33736</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33736</field>
+<field name="lastModifyDate">2018-07-17 11:47:33.52</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33383</identifier><datestamp>2018-07-12T18:20:39Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Gholson, Lilian</field>
+<field name="value">Ersholz, Scott</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:37Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:37Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2015-02-24</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33383</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20150224_Lillian_Gholson</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Mrs. Lillian Gholson, founding manager of the Randolph Branch library (Memphis Public Library) is interviewed by current manager of Randolph, Scott Elsholz. Part of The Heights Neighborhood History collection and the Crossroads to Freedom digital archive.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278737921</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Memphis Public Library</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Lilian Gholson, 2015</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150224_Lillian_Gholson</field>
+<field name="originalName">20150224_Lillian_Gholson</field>
+<field name="format">image/png</field>
+<field name="size">302338</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33383/1/20150224_Lillian_Gholson</field>
+<field name="checksum">dbf6c2634c54c821d655bce1fd90f44d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20150224_Lillian_Gholson.pdf</field>
+<field name="originalName">20150224_Lillian_Gholson.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">188492</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33383/4/20150224_Lillian_Gholson.pdf</field>
+<field name="checksum">6b37b9a5c5fa0853f755911a7f1123a8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">lilian gholson.PNG.jpg</field>
+<field name="originalName">lilian gholson.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7520</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33383/2/lilian%20gholson.PNG.jpg</field>
+<field name="checksum">dfe54af09aefba8b36075091b8e7e82d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20150224_Lillian_Gholson.pdf.jpg</field>
+<field name="originalName">20150224_Lillian_Gholson.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11168</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33383/6/20150224_Lillian_Gholson.pdf.jpg</field>
+<field name="checksum">28e50a66ab39b3867aadcd908b38356a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20150224_Lillian_Gholson.jpg</field>
+<field name="originalName">20150224_Lillian_Gholson.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7520</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33383/7/20150224_Lillian_Gholson.jpg</field>
+<field name="checksum">dfe54af09aefba8b36075091b8e7e82d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">lilian gholson.PNG.preview.jpg</field>
+<field name="originalName">lilian gholson.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">20387</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33383/3/lilian%20gholson.PNG.preview.jpg</field>
+<field name="checksum">0251fa4451e06798c3801c23776608db</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20150224_Lillian_Gholson.preview.jpg</field>
+<field name="originalName">20150224_Lillian_Gholson.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">20387</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33383/8/20150224_Lillian_Gholson.preview.jpg</field>
+<field name="checksum">0251fa4451e06798c3801c23776608db</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150224_Lillian_Gholson.pdf.txt</field>
+<field name="originalName">20150224_Lillian_Gholson.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">42061</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33383/5/20150224_Lillian_Gholson.pdf.txt</field>
+<field name="checksum">eb87575eae1ba44ac5ed9f6c3fe31f92</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33383</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33383</field>
+<field name="lastModifyDate">2018-07-12 13:20:39.031</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33482</identifier><datestamp>2018-07-16T17:04:50Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Haggard, David</field>
+<field name="value">Watson, Shane</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-16T16:46:36Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-16T16:46:36Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-06-08</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33482</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140608_David_Haggard</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">David Haggard is a park ranger with Tennessee State Parks and works at Reel Foot Lake. He talks about growing up in east Tennessee and his job now.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279912485</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Lake County (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Reelfoot Lake State Park (Tenn.)</field>
+<field name="value">Park rangers</field>
+<field name="value">Tennessee, East--History</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">David Haggard, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140608_David_Haggard.JPG</field>
+<field name="originalName">20140608_David_Haggard.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">159053</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33482/1/20140608_David_Haggard.JPG</field>
+<field name="checksum">6a2ce9f492c4f083741a94e3888b5252</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140608_David_Haggard.pdf</field>
+<field name="originalName">20140608_David_Haggard.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">156127</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33482/2/20140608_David_Haggard.pdf</field>
+<field name="checksum">8868b87196728b764e21f674f1645d98</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140608_David_Haggard.JPG.jpg</field>
+<field name="originalName">20140608_David_Haggard.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">15056</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33482/3/20140608_David_Haggard.JPG.jpg</field>
+<field name="checksum">38737cbe0c06598ea2d47a2a9ea28942</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140608_David_Haggard.pdf.jpg</field>
+<field name="originalName">20140608_David_Haggard.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11939</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33482/6/20140608_David_Haggard.pdf.jpg</field>
+<field name="checksum">d2d7f07b4f1f5fead1c4908bb6fd2efe</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140608_David_Haggard.JPG.preview.jpg</field>
+<field name="originalName">20140608_David_Haggard.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">67545</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33482/4/20140608_David_Haggard.JPG.preview.jpg</field>
+<field name="checksum">8331b43a8f24568946665989fac3d52d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140608_David_Haggard.pdf.txt</field>
+<field name="originalName">20140608_David_Haggard.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">19656</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33482/5/20140608_David_Haggard.pdf.txt</field>
+<field name="checksum">ab965dc04de55b9b4b0275286b51a3f3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33482</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33482</field>
+<field name="lastModifyDate">2018-07-16 12:04:50.03</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33362</identifier><datestamp>2018-07-17T16:42:04Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Looney, Brittany</field>
+<field name="value">Lemus, Kimberly</field>
+<field name="value">Martin, George</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:33Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:33Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-06-26</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33362</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130626_George_Martin</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">George Martin shares his experiences growing up in the Memphis neighborhood Highland Heights and his current involvement with the Highland Heights Corners community.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280396087</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">George Martin, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_George_Martin.pdf</field>
+<field name="originalName">20130626_George_Martin.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">144666</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33362/1/20130626_George_Martin.pdf</field>
+<field name="checksum">2594044461d9c54805aecb5c2b4e876b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_George_Martin</field>
+<field name="originalName">20130626_George_Martin</field>
+<field name="format">image/png</field>
+<field name="size">295545</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33362/2/20130626_George_Martin</field>
+<field name="checksum">35117ebcc1f71dea42d50cd8d868f2b8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_George_Martin.pdf.txt</field>
+<field name="originalName">20130626_George_Martin.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">15873</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33362/3/20130626_George_Martin.pdf.txt</field>
+<field name="checksum">e39b0c40a72af2bcba4a6444a1ff88ca</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_George_Martin.pdf.jpg</field>
+<field name="originalName">20130626_George_Martin.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10109</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33362/4/20130626_George_Martin.pdf.jpg</field>
+<field name="checksum">ee7f4107f3c8b4889f6075937c0e4eec</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">capture.jpg</field>
+<field name="originalName">capture.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7016</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33362/5/capture.jpg</field>
+<field name="checksum">8a14cf6339702034fdc51729a1282a58</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_George_Martin.jpg</field>
+<field name="originalName">20130626_George_Martin.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7016</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33362/7/20130626_George_Martin.jpg</field>
+<field name="checksum">8a14cf6339702034fdc51729a1282a58</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">capture.preview.jpg</field>
+<field name="originalName">capture.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">18900</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33362/6/capture.preview.jpg</field>
+<field name="checksum">efa3619a4c70dbb8a5a66fc1db1c70c9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_George_Martin.preview.jpg</field>
+<field name="originalName">20130626_George_Martin.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">18900</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33362/8/20130626_George_Martin.preview.jpg</field>
+<field name="checksum">efa3619a4c70dbb8a5a66fc1db1c70c9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33362</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33362</field>
+<field name="lastModifyDate">2018-07-17 11:42:04.654</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33705</identifier><datestamp>2018-10-17T16:30:28Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Walker, Regina</field>
+<field name="value">Threatt, Brittney M.</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-12T15:31:01Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-12T15:31:01Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2017-07-11</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33705</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20170711_Regina_Walker</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, Regina Walker dissucess her past experiences dealing with race and social justice in Memphis. Interviewed by Brittney Threatt ('17).</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278585964</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Rhodes College</field>
+<field name="value">Education</field>
+<field name="value">Race relations</field>
+<field name="value">Social justice</field>
+<field name="value">African Americans</field>
+<field name="value">Women</field>
+<field name="value">United Way</field>
+<field name="value">Black Leaders</field>
+<field name="value">2017 Summer</field>
+<field name="value">Class of 2017</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Regina Walker, 2017</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170711_Regina_Walker.JPG</field>
+<field name="originalName">20170711_Regina_Walker.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">59760</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33705/1/20170711_Regina_Walker.JPG</field>
+<field name="checksum">8b5225b29b43bf4c151c8a50ef43d34b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20170711_Regina_Walker.pdf</field>
+<field name="originalName">20170711_Regina_Walker.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">247648</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33705/4/20170711_Regina_Walker.pdf</field>
+<field name="checksum">b614ecd585ff5d86a70e4d1c766a296a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170711_Regina_Walker.JPG.jpg</field>
+<field name="originalName">20170711_Regina_Walker.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7066</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33705/2/20170711_Regina_Walker.JPG.jpg</field>
+<field name="checksum">987089d1ad152d81ad796ba9fc148004</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20170711_Regina_Walker.pdf.jpg</field>
+<field name="originalName">20170711_Regina_Walker.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10853</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33705/6/20170711_Regina_Walker.pdf.jpg</field>
+<field name="checksum">e43011b3796583ab09872947907d31d7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170711_Regina_Walker.JPG.preview.jpg</field>
+<field name="originalName">20170711_Regina_Walker.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">26219</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33705/3/20170711_Regina_Walker.JPG.preview.jpg</field>
+<field name="checksum">615d22d77a61862d5d906f53fbdef0be</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170711_Regina_Walker.pdf.txt</field>
+<field name="originalName">20170711_Regina_Walker.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">111647</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33705/5/20170711_Regina_Walker.pdf.txt</field>
+<field name="checksum">f98c14fd4ebc6a150742f470e32ca6fe</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33705</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33705</field>
+<field name="lastModifyDate">2018-10-17 11:30:28.885</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33544</identifier><datestamp>2018-08-01T20:53:38Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Mitchell, Stuart</field>
+<field name="value">Neeson, Sophia</field>
+<field name="value">Scanlon, Connor</field>
+<field name="value">Bonefas, Suzanne</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T14:48:51Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T14:48:51Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2015-08-13</field>
+</element>
+</element>
+<element name="graduation">
+<element name="none">
+<field name="value">2017</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33544</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20150813_Stuart_Mitchell</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Stuart Mitchell, conducted by Sophia Neeson, Connor Scanlon ('17), and Dr. Suzanne Bonefas.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/282745921</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Stuart Mitchell, 2015</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150813_Stuart_Mitchell.PNG.jpg</field>
+<field name="originalName">20150813_Stuart_Mitchell.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6612</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33544/3/20150813_Stuart_Mitchell.PNG.jpg</field>
+<field name="checksum">6d878999dfd9d879a49fd5a580cef0e9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20150813_Stuart_Mitchell.pdf.jpg</field>
+<field name="originalName">20150813_Stuart_Mitchell.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11116</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33544/6/20150813_Stuart_Mitchell.pdf.jpg</field>
+<field name="checksum">a3f98482f4cb5ba8f341073f8667571b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150813_Stuart_Mitchell.PNG.preview.jpg</field>
+<field name="originalName">20150813_Stuart_Mitchell.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">24527</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33544/4/20150813_Stuart_Mitchell.PNG.preview.jpg</field>
+<field name="checksum">0120c7f990cdb4f07a1b986fee8b7dc5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150813_Stuart_Mitchell.pdf.txt</field>
+<field name="originalName">20150813_Stuart_Mitchell.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">32146</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33544/5/20150813_Stuart_Mitchell.pdf.txt</field>
+<field name="checksum">4c6f350052b3d737cb5a93125886de95</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150813_Stuart_Mitchell.PNG</field>
+<field name="originalName">20150813_Stuart_Mitchell.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1321554</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33544/1/20150813_Stuart_Mitchell.PNG</field>
+<field name="checksum">0da10081f1ac037ab37fd9c029769025</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20150813_Stuart_Mitchell.pdf</field>
+<field name="originalName">20150813_Stuart_Mitchell.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">178642</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33544/2/20150813_Stuart_Mitchell.pdf</field>
+<field name="checksum">f0e5dfd40fdd85ea06deaecaecf0a140</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33544</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33544</field>
+<field name="lastModifyDate">2018-08-01 15:53:38.32</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33621</identifier><datestamp>2018-08-01T20:32:03Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Ross, Dennis</field>
+<field name="value">Young, Stevion</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:21Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:21Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-07-03</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33621</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140703_Dennis_Ross</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Dennis Ross, Pastor of the Evening Star Missionary Baptist Church, shares his experiences growing up and living in South Memphis during the 1960's.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279681778</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Dennis Ross, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140703_Dennis_Ross.JPG</field>
+<field name="originalName">20140703_Dennis_Ross.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">38976</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33621/1/20140703_Dennis_Ross.JPG</field>
+<field name="checksum">6671671d1c51482154e280f7af313a76</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140703_Dennis_Ross.pdf</field>
+<field name="originalName">20140703_Dennis_Ross.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">240204</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33621/2/20140703_Dennis_Ross.pdf</field>
+<field name="checksum">cad7cde98c82149f622cc3a7fd311d59</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140703_Dennis_Ross.JPG.jpg</field>
+<field name="originalName">20140703_Dennis_Ross.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">4634</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33621/3/20140703_Dennis_Ross.JPG.jpg</field>
+<field name="checksum">9bbaf0cc259f2f561c25a61613015cf0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140703_Dennis_Ross.pdf.jpg</field>
+<field name="originalName">20140703_Dennis_Ross.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12059</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33621/6/20140703_Dennis_Ross.pdf.jpg</field>
+<field name="checksum">9aee0e0d87fac8f8b54ce3c079aaeeea</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140703_Dennis_Ross.JPG.preview.jpg</field>
+<field name="originalName">20140703_Dennis_Ross.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">18502</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33621/4/20140703_Dennis_Ross.JPG.preview.jpg</field>
+<field name="checksum">718a132a71ab0a1a17492ceabc0b92dc</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140703_Dennis_Ross.pdf.txt</field>
+<field name="originalName">20140703_Dennis_Ross.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">21621</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33621/5/20140703_Dennis_Ross.pdf.txt</field>
+<field name="checksum">f0b47e5a80054978dfeea0b6728f4bf4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33621</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33621</field>
+<field name="lastModifyDate">2018-08-01 15:32:03.429</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33550</identifier><datestamp>2018-07-20T17:12:14Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Turley, Lynne</field>
+<field name="value">Davis, Francesca</field>
+<field name="value">Williams, Rebecca</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T15:16:03Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T15:16:03Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2006-06-20</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33550</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20060620_Lynne_Turley</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Lynne Turley describes her experience as a music teacher in the Memphis City School System when Martin Luther King, Jr. was assassinated.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278536873</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Music</field>
+<field name="value">Memphis City Schools</field>
+<field name="value">Education</field>
+<field name="value">King, Martin Luther, Jr., 1929-1968</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Lynne Turley, 2006</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20060620_Lynne_Turley.jpg</field>
+<field name="originalName">20060620_Lynne_Turley.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">231926</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33550/1/20060620_Lynne_Turley.jpg</field>
+<field name="checksum">b793b28819dcab6e0e8afde857ea1e23</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20060620_Lynne_Turley.pdf</field>
+<field name="originalName">20060620_Lynne_Turley.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">147975</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33550/2/20060620_Lynne_Turley.pdf</field>
+<field name="checksum">35c7ed5f706f6cc20038bd1d24ed3c51</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20060620_Lynne_Turley.jpg.jpg</field>
+<field name="originalName">20060620_Lynne_Turley.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13782</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33550/3/20060620_Lynne_Turley.jpg.jpg</field>
+<field name="checksum">988275bc89fd95276245248288e40a3c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20060620_Lynne_Turley.pdf.jpg</field>
+<field name="originalName">20060620_Lynne_Turley.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13924</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33550/6/20060620_Lynne_Turley.pdf.jpg</field>
+<field name="checksum">8f51711b6c33f403a55ba3e17c87e487</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20060620_Lynne_Turley.jpg.preview.jpg</field>
+<field name="originalName">20060620_Lynne_Turley.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">58217</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33550/4/20060620_Lynne_Turley.jpg.preview.jpg</field>
+<field name="checksum">60e724fafc54c0a0d839431e129a7998</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20060620_Lynne_Turley.pdf.txt</field>
+<field name="originalName">20060620_Lynne_Turley.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">34102</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33550/5/20060620_Lynne_Turley.pdf.txt</field>
+<field name="checksum">b96982427c47b3ec7292d1ec86a28de1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33550</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33550</field>
+<field name="lastModifyDate">2018-07-20 12:12:14.386</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31280</identifier><datestamp>2018-07-17T19:24:56Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Hughes, Charles L.</field>
+<field name="value">The Temprees</field>
+<field name="value">Calvin, Deljuan (Del)</field>
+<field name="value">Calvin, Jerry (JC)</field>
+<field name="value">Scott, Harold</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-01-17T22:05:12Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-01-17T22:05:12Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2004-09-01</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31280</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Collection: Stax Museum Oral Histories Interviewees: Deljuan Calvin, JC Calvin, and Harold Scott (The Temprees) Date: 2004-08-01</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279728144</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Music</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Stax Records</field>
+<field name="value">Temprees (Musical group)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">The Temprees, 2004</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.jpg.jpg</field>
+<field name="originalName">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11217</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31280/3/20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.jpg.jpg</field>
+<field name="checksum">74f07c0d6c439e844eb409ca78e0c1dd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.pdf.jpg</field>
+<field name="originalName">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10099</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31280/5/20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.pdf.jpg</field>
+<field name="checksum">727e6fdf95254641c26dec45c973cbf5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.pdf.txt</field>
+<field name="originalName">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">43009</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31280/4/20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.pdf.txt</field>
+<field name="checksum">5fc812700cbacbef8764ac1f77542640</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.jpg</field>
+<field name="originalName">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">135101</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31280/1/20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.jpg</field>
+<field name="checksum">cf908df38239d472d57f091ece3d471c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.pdf</field>
+<field name="originalName">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">77953</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31280/2/20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.pdf</field>
+<field name="checksum">fa89ce098ba7f47b2b0a631654f3ef77</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.jpg.preview.jpg</field>
+<field name="originalName">20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">45481</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31280/6/20040827_the_Temprees_Jerry_Calvin_Calvin_and_Scott.jpg.preview.jpg</field>
+<field name="checksum">d0e959435856bfd3bf91b1bb59126434</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31280</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31280</field>
+<field name="lastModifyDate">2018-07-17 14:24:56.421</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33499</identifier><datestamp>2018-07-27T16:34:38Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Wimmer, Judy</field>
+<field name="value">Davis, Francesca</field>
+<field name="value">Borst-Censullo, Stefan</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T15:23:58Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T15:23:58Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-07-27</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33499</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20070727_Judy_Wimmer</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Judy Wimmer, who is currently a photographer. Wimmer gives a unique perspective of Memphis during the 1950s. After moving to the affluent neighborhood of Whitehaven, which was predominantly Jewish, she had difficulties adjusting because of her Catholic faith. During the push for Civil Rights, she was involved in many progressive organizations such as the Panel of American Women with Modeane Thompson, Rearing Children of Goodwill, and Concerned Women of Memphis and Shelby County.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278558768</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Whitehaven (Memphis, Tenn.)</field>
+<field name="value">Religion</field>
+<field name="value">Gender</field>
+<field name="value">Civil rights</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Race relations</field>
+<field name="value">Integration</field>
+<field name="value">Panel of American Women</field>
+<field name="value">Smith, Maxine</field>
+<field name="value">Thompson, Modeane</field>
+<field name="value">King, Martin Luther, Jr., 1929-1968</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Judy Wimmer, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070727_Judy_Wimmer.pdf</field>
+<field name="originalName">20070727_Judy_Wimmer.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">178107</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33499/1/20070727_Judy_Wimmer.pdf</field>
+<field name="checksum">1982c639d215c580677aa00cbe4c04c7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20070727_Judy_Wimmer.JPG</field>
+<field name="originalName">20070727_Judy_Wimmer.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">57911</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33499/2/20070727_Judy_Wimmer.JPG</field>
+<field name="checksum">ba8b49800ec55547f78a29841713a156</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070727_Judy_Wimmer.pdf.txt</field>
+<field name="originalName">20070727_Judy_Wimmer.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">35502</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33499/3/20070727_Judy_Wimmer.pdf.txt</field>
+<field name="checksum">909597082a9ef6d9ed870c9ad5fd60e6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070727_Judy_Wimmer.pdf.jpg</field>
+<field name="originalName">20070727_Judy_Wimmer.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13716</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33499/4/20070727_Judy_Wimmer.pdf.jpg</field>
+<field name="checksum">869732a885c52188496cd0b70317f5b8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20070727_Judy_Wimmer.JPG.jpg</field>
+<field name="originalName">20070727_Judy_Wimmer.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13035</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33499/5/20070727_Judy_Wimmer.JPG.jpg</field>
+<field name="checksum">b8504c6e1d2be14c3046b45e254a5445</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070727_Judy_Wimmer.JPG.preview.jpg</field>
+<field name="originalName">20070727_Judy_Wimmer.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">39947</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33499/6/20070727_Judy_Wimmer.JPG.preview.jpg</field>
+<field name="checksum">73a0c56ce22b96d4390886f0e73abccd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33499</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33499</field>
+<field name="lastModifyDate">2018-07-27 11:34:38.871</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33659</identifier><datestamp>2018-07-12T18:20:39Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Wharton, A C, Jr., 1944-</field>
+<field name="value">James, Holly</field>
+<field name="value">Smith, Tiffani</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T20:59:22Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T20:59:22Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2008-06-26</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33659</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20080626_A_C_Wharton</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Mayor A.C. Wharton, who served as the mayor of Shelby County, Tennessee from 2002-2009, and mayor of Memphis since 2009. In this clip he describes what it was like as a college student at Tennessee State University, in Nashville, Tennessee, during the Civil rights Era.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="none">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278569549</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Wharton, A C, Jr., 1944-</field>
+<field name="value">Tennessee State University</field>
+<field name="value">Nashville (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Race relations</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">A. C. Wharton, 2008</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080626_A_C_Wharton.JPG</field>
+<field name="originalName">20080626_A_C_Wharton.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">104635</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33659/1/20080626_A_C_Wharton.JPG</field>
+<field name="checksum">e5cc151dfe7227c6feb0cea709713ce2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20080626_A_C_Wharton.pdf</field>
+<field name="originalName">20080626_A_C_Wharton.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">231649</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33659/2/20080626_A_C_Wharton.pdf</field>
+<field name="checksum">9047079cbe0b41fc1bc56f9cb3cabfaf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080626_A_C_Wharton.JPG.jpg</field>
+<field name="originalName">20080626_A_C_Wharton.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12601</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33659/3/20080626_A_C_Wharton.JPG.jpg</field>
+<field name="checksum">63639f28286be5ff151922f414e13825</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20080626_A_C_Wharton.pdf.jpg</field>
+<field name="originalName">20080626_A_C_Wharton.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13107</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33659/6/20080626_A_C_Wharton.pdf.jpg</field>
+<field name="checksum">7d5a271532be93ec2969a4ea93da1eda</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080626_A_C_Wharton.JPG.preview.jpg</field>
+<field name="originalName">20080626_A_C_Wharton.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">47568</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33659/4/20080626_A_C_Wharton.JPG.preview.jpg</field>
+<field name="checksum">a7ded7278eb08888c02eef56364cd864</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080626_A_C_Wharton.pdf.txt</field>
+<field name="originalName">20080626_A_C_Wharton.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">54256</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33659/5/20080626_A_C_Wharton.pdf.txt</field>
+<field name="checksum">ac5d519526be5b74faef6291e030d802</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33659</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33659</field>
+<field name="lastModifyDate">2018-07-12 13:20:39.186</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31287</identifier><datestamp>2018-07-16T20:22:09Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Drake, Carol</field>
+<field name="value">Nix, Larry</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-01-17T22:05:13Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-01-17T22:05:13Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2004-06-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31287</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20070618_Larry_Nix</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Larry Nix conducted by Carol Drake on June 17th, 2004. Larry is the brother of musician Don Nix. He was a mastering engineer for Stax and the Ardent Recording Studios in Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280251818</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Music</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Stax Records</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Larry Nix, 2004</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040617_Larry_Nix_transcript.jpg.jpg</field>
+<field name="originalName">20040617_Larry_Nix_transcript.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">5881</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31287/3/20040617_Larry_Nix_transcript.jpg.jpg</field>
+<field name="checksum">df252ad1d0c9381311c1fa7c3c713e12</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20040617_Larry_Nix_transcript.pdf.jpg</field>
+<field name="originalName">20040617_Larry_Nix_transcript.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">3520</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31287/5/20040617_Larry_Nix_transcript.pdf.jpg</field>
+<field name="checksum">3d9f094cb748237d77084d63ca301117</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040617_Larry_Nix_transcript.pdf.txt</field>
+<field name="originalName">20040617_Larry_Nix_transcript.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">23354</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31287/4/20040617_Larry_Nix_transcript.pdf.txt</field>
+<field name="checksum">a68caf79dc9db5a59f3771149636e72d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040617_Larry_Nix_transcript.jpg</field>
+<field name="originalName">20040617_Larry_Nix_transcript.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">61269</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31287/1/20040617_Larry_Nix_transcript.jpg</field>
+<field name="checksum">0c429e2b065097e85558f557f3d07174</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20040617_Larry_Nix_transcript.pdf</field>
+<field name="originalName">20040617_Larry_Nix_transcript.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">1220942</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31287/2/20040617_Larry_Nix_transcript.pdf</field>
+<field name="checksum">6cc1df38124f445d1dad850450592ff3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040617_Larry_Nix_transcript.jpg.preview.jpg</field>
+<field name="originalName">20040617_Larry_Nix_transcript.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">20644</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31287/6/20040617_Larry_Nix_transcript.jpg.preview.jpg</field>
+<field name="checksum">647423050f667b6c8d2062b6da75a001</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31287</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31287</field>
+<field name="lastModifyDate">2018-07-16 15:22:09.841</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33574</identifier><datestamp>2018-07-17T19:09:32Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Buckman, Bob</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-22T19:45:59Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-22T19:45:59Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2012-05-23</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33574</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20120523_Bob_Buckman</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Interviewee: Bob Buckman Date: May 23, 2012</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278731672</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Bob Buckman, 2012</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20120523_Bob_Buckman.txt.txt</field>
+<field name="originalName">20120523_Bob_Buckman.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">49963</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33574/7/20120523_Bob_Buckman.txt.txt</field>
+<field name="checksum">c496ee391a189b5a637bbd51b4fbea14</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.PNG.jpg</field>
+<field name="originalName">Capture.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7334</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33574/2/Capture.PNG.jpg</field>
+<field name="checksum">033f582e190c28ff57db1554a8108483</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20120523_Bob_Buckman.PNG.jpg</field>
+<field name="originalName">20120523_Bob_Buckman.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7334</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33574/4/20120523_Bob_Buckman.PNG.jpg</field>
+<field name="checksum">033f582e190c28ff57db1554a8108483</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.PNG.preview.jpg</field>
+<field name="originalName">Capture.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">26789</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33574/3/Capture.PNG.preview.jpg</field>
+<field name="checksum">10f56ba6634dc996307cfe6b0d803e8d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20120523_Bob_Buckman.PNG.preview.jpg</field>
+<field name="originalName">20120523_Bob_Buckman.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">26789</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33574/5/20120523_Bob_Buckman.PNG.preview.jpg</field>
+<field name="checksum">10f56ba6634dc996307cfe6b0d803e8d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20120523_Bob_Buckman.PNG</field>
+<field name="originalName">20120523_Bob_Buckman.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1532872</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33574/1/20120523_Bob_Buckman.PNG</field>
+<field name="checksum">a9026884e21931038367ae01ff9c47d7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20120523_Bob_Buckman.txt</field>
+<field name="originalName">20120523_Bob_Buckman.txt</field>
+<field name="format">text/plain</field>
+<field name="size">53473</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33574/6/20120523_Bob_Buckman.txt</field>
+<field name="checksum">38dc2ab874669549581148d652951709</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33574</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33574</field>
+<field name="lastModifyDate">2018-07-17 14:09:32.617</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33697</identifier><datestamp>2018-07-12T18:20:39Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Crain, Frances Utterback</field>
+<field name="value">McGlown, Holly</field>
+<field name="value">Mulloy, Caroline</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-04T18:01:14Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-04T18:01:14Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2010-07-21</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33697</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20100721_Frances_Crain</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Frances Crain. She was an active member of the Memphis community who spent her life bringing people from all walks of life into her home.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278721704</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Evergreen Historic District (Memphis, Tenn.)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Frances Crain, 2010</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100721_Frances_Crain.JPG</field>
+<field name="originalName">20100721_Frances_Crain.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">79405</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33697/1/20100721_Frances_Crain.JPG</field>
+<field name="checksum">8ea469cccb1cd7cc8c47bf0c99d9431b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20100721_Frances_Crain.pdf</field>
+<field name="originalName">20100721_Frances_Crain.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">169578</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33697/2/20100721_Frances_Crain.pdf</field>
+<field name="checksum">9e82928c15cbb2b795ef6c8ddb31b4a4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100721_Frances_Crain.JPG.jpg</field>
+<field name="originalName">20100721_Frances_Crain.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9299</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33697/3/20100721_Frances_Crain.JPG.jpg</field>
+<field name="checksum">99d726eb755568fc35c26181e9c4e586</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20100721_Frances_Crain.pdf.jpg</field>
+<field name="originalName">20100721_Frances_Crain.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12685</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33697/6/20100721_Frances_Crain.pdf.jpg</field>
+<field name="checksum">004a2033e9fc5f9523b6d98e4ae3332a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100721_Frances_Crain.JPG.preview.jpg</field>
+<field name="originalName">20100721_Frances_Crain.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">36018</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33697/4/20100721_Frances_Crain.JPG.preview.jpg</field>
+<field name="checksum">61a148e99beb5ff6d70962d3aa087465</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100721_Frances_Crain.pdf.txt</field>
+<field name="originalName">20100721_Frances_Crain.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">26019</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33697/5/20100721_Frances_Crain.pdf.txt</field>
+<field name="checksum">495a7a8c2c80cb7d6f5c98a26b956ac2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33697</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33697</field>
+<field name="lastModifyDate">2018-07-12 13:20:39.334</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33530</identifier><datestamp>2018-07-17T14:16:25Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Pruitt, Stephen</field>
+<field name="value">Rutherford, George</field>
+<field name="value">Wainwright, John</field>
+<field name="value">Bland, Jacqueline</field>
+<field name="value">Coleman, Gary</field>
+<field name="value">Norfleet, Treshain</field>
+<field name="value">Murray, Missy</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T16:29:22Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T16:29:22Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2010-07-16</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33530</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20100716_Northside.Alumni.Association</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with five alums of Northside High School, a high school that draws from the Hyde Park area. All of them graduated in 1968 and 1969 and they talk about their experiences with the civil rights movement and especially the effects of integration on them personally. Video in the Crossroads to Freedom repository.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280268258</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Hyde Park (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Civil rights</field>
+<field name="value">Education</field>
+<field name="value">Northside High School (Memphis, Tenn.)</field>
+<field name="value">Integration</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Interview with Northside High School Alums, 2010</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100716_Northside.Alumni.Association.PNG</field>
+<field name="originalName">20100716_Northside.Alumni.Association.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1518278</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33530/1/20100716_Northside.Alumni.Association.PNG</field>
+<field name="checksum">57b61ded8d0ea7003cadd7af3148214f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20100716_Northside.Alumni.Association.pdf</field>
+<field name="originalName">20100716_Northside.Alumni.Association.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">220869</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33530/2/20100716_Northside.Alumni.Association.pdf</field>
+<field name="checksum">487a435e1f088d855093ab8437f78a8f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100716_Northside.Alumni.Association.PNG.jpg</field>
+<field name="originalName">20100716_Northside.Alumni.Association.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13162</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33530/3/20100716_Northside.Alumni.Association.PNG.jpg</field>
+<field name="checksum">22686f6d0f8ffff137f62eebb2eda81c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20100716_Northside.Alumni.Association.pdf.jpg</field>
+<field name="originalName">20100716_Northside.Alumni.Association.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12920</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33530/6/20100716_Northside.Alumni.Association.pdf.jpg</field>
+<field name="checksum">edab070b2619dd59d3dfcab104a00a90</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100716_Northside.Alumni.Association.PNG.preview.jpg</field>
+<field name="originalName">20100716_Northside.Alumni.Association.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">47658</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33530/4/20100716_Northside.Alumni.Association.PNG.preview.jpg</field>
+<field name="checksum">d14fb85f0deebed4aed7659a90e54f0f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100716_Northside.Alumni.Association.pdf.txt</field>
+<field name="originalName">20100716_Northside.Alumni.Association.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">50336</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33530/5/20100716_Northside.Alumni.Association.pdf.txt</field>
+<field name="checksum">41718143656f315dedbcd200ffdf517b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33530</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33530</field>
+<field name="lastModifyDate">2018-07-17 09:16:25.65</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33481</identifier><datestamp>2018-08-01T20:24:19Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Ross, Gregory</field>
+<field name="value">Kimble, Cedric</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-16T16:46:36Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-16T16:46:36Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-06-18</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33481</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140618_Gregory_Ross</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Gregory Ross shares his experiences growing up and living in Lake County, TN. He praises the role of sports in his personal development, and expresses thanks to his home place for giving him these types of opportunities.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279913651</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Lake County (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Sports</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Greg Ross, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140618_Gregory_Ross.JPG</field>
+<field name="originalName">20140618_Gregory_Ross.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">60242</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33481/1/20140618_Gregory_Ross.JPG</field>
+<field name="checksum">7e508a9a0196bb329a67a2db02764a24</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140618_Gregory_Ross.pdf</field>
+<field name="originalName">20140618_Gregory_Ross.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">155517</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33481/2/20140618_Gregory_Ross.pdf</field>
+<field name="checksum">ad813814b845ef92be2e3c4f566c10b2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140618_Gregory_Ross.JPG.jpg</field>
+<field name="originalName">20140618_Gregory_Ross.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8052</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33481/3/20140618_Gregory_Ross.JPG.jpg</field>
+<field name="checksum">3240359ebec1c59a8c86f9f190f99be7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140618_Gregory_Ross.pdf.jpg</field>
+<field name="originalName">20140618_Gregory_Ross.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10202</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33481/6/20140618_Gregory_Ross.pdf.jpg</field>
+<field name="checksum">c2b39e2906d269d05dcd095ef71b0db1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140618_Gregory_Ross.JPG.preview.jpg</field>
+<field name="originalName">20140618_Gregory_Ross.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">29863</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33481/4/20140618_Gregory_Ross.JPG.preview.jpg</field>
+<field name="checksum">2863d645b4799d1039f445b1b24069dc</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140618_Gregory_Ross.pdf.txt</field>
+<field name="originalName">20140618_Gregory_Ross.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">17153</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33481/5/20140618_Gregory_Ross.pdf.txt</field>
+<field name="checksum">22bdf6943994ef72971c68d922c68d2d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33481</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33481</field>
+<field name="lastModifyDate">2018-08-01 15:24:19.096</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33704</identifier><datestamp>2018-07-12T18:20:39Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Wigginton, Russell Thomas</field>
+<field name="value">Threatt, Brittney M.</field>
+<field name="value">Jones, Zaria D.</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-12T15:31:00Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-12T15:31:00Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2017-07-05</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33704</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20170705_Russ_Wigginton</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, alumus and former professor Dr. Russell T. Wigginton ('88) discusses past experiences and reflects on his time at Rhodes College. Interview conducted by Brittney Threatt ('17) and Zaria Jones ('19).</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278585805</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Rhodes College</field>
+<field name="value">Education</field>
+<field name="value">Class of 2017</field>
+<field name="value">Class of 1988</field>
+<field name="value">Class of 2019</field>
+<field name="value">2017 Summer</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Dr. Russell T. Wigginton, 2017</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170705_Russ_Wigginton.JPG.jpg</field>
+<field name="originalName">20170705_Russ_Wigginton.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12210</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33704/2/20170705_Russ_Wigginton.JPG.jpg</field>
+<field name="checksum">c683f571b16dc9521c26ddebd34d074a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20170705_Russ_Wigginton.pdf.jpg</field>
+<field name="originalName">20170705_Russ_Wigginton.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11294</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33704/6/20170705_Russ_Wigginton.pdf.jpg</field>
+<field name="checksum">d823fbd7deead5d589fc605264d4d891</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170705_Russ_Wigginton.JPG.preview.jpg</field>
+<field name="originalName">20170705_Russ_Wigginton.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">46204</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33704/3/20170705_Russ_Wigginton.JPG.preview.jpg</field>
+<field name="checksum">8a18b2429a49a69b40d00b245a2f755c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170705_Russ_Wigginton.pdf.txt</field>
+<field name="originalName">20170705_Russ_Wigginton.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">61536</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33704/5/20170705_Russ_Wigginton.pdf.txt</field>
+<field name="checksum">ebdc8c599ddd4e16387bf47cbad76570</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170705_Russ_Wigginton.JPG</field>
+<field name="originalName">20170705_Russ_Wigginton.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">91494</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33704/1/20170705_Russ_Wigginton.JPG</field>
+<field name="checksum">396142541dcd77002b2d3db4965502a3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20170705_Russ_Wigginton.pdf</field>
+<field name="originalName">20170705_Russ_Wigginton.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">260786</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33704/4/20170705_Russ_Wigginton.pdf</field>
+<field name="checksum">1b7d2d7d412110fec352813d4f0aa0c3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33704</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33704</field>
+<field name="lastModifyDate">2018-07-12 13:20:39.642</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33464</identifier><datestamp>2018-07-26T17:59:53Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Ross, Gregory</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-16T16:46:31Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-16T16:46:31Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2015-06-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33464</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20150630_Greg_Ross</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Gregory Ross shares his experiences growing up and living in Lake County, TN.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/281660813</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Lake County (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Greg Ross, 2015</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150630_Greg_Ross.pdf</field>
+<field name="originalName">20150630_Greg_Ross.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">473657</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33464/1/20150630_Greg_Ross.pdf</field>
+<field name="checksum">fa050e0bd62d627ce2602f8e62739cfb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20150630_Greg_Ross.JPG</field>
+<field name="originalName">20150630_Greg_Ross.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">35871</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33464/4/20150630_Greg_Ross.JPG</field>
+<field name="checksum">fd8308d51493527e5fadf84e3536683f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150630_Greg_Ross.pdf.txt</field>
+<field name="originalName">20150630_Greg_Ross.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">11818</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33464/5/20150630_Greg_Ross.pdf.txt</field>
+<field name="checksum">6db1c17c04fd58e1a8a9a85ad4805b65</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150630_Greg_Ross.pdf.jpg</field>
+<field name="originalName">20150630_Greg_Ross.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12519</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33464/6/20150630_Greg_Ross.pdf.jpg</field>
+<field name="checksum">21c7d0c494d1240e12b0b50ef02cb709</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20150630_Greg_Ross.JPG.jpg</field>
+<field name="originalName">20150630_Greg_Ross.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9741</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33464/7/20150630_Greg_Ross.JPG.jpg</field>
+<field name="checksum">88eb0ed270d80860aca1837de4e3d0a6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150630_Greg_Ross.JPG.preview.jpg</field>
+<field name="originalName">20150630_Greg_Ross.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">27838</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33464/8/20150630_Greg_Ross.JPG.preview.jpg</field>
+<field name="checksum">c8db1486d9d8c68c914f85651e6de246</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33464</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33464</field>
+<field name="lastModifyDate">2018-07-26 12:59:53.437</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33516</identifier><datestamp>2018-07-27T19:20:19Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Mildred, Harris</field>
+<field name="value">Westbrook, Paris</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T16:29:17Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T16:29:17Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2009-06-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33516</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20090630_Mildred_Harris</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Mildred Harris. During this interview, Harris describes her childhood in Oakland, Tennessee before she moved to Memphis in 1951. Harris also talks about her experiences in Memphis which include working and raising her children. She also provides us with valuable life lessons that she taught her children.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278575942</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Hyde Park (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Oakland (Tenn.)</field>
+<field name="value">Race relations</field>
+<field name="value">Sanitation Workers Strike, Memphis, Tenn., 1968</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Mildred Harris, 2009</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090630_Mildred_Harris.PNG</field>
+<field name="originalName">20090630_Mildred_Harris.PNG</field>
+<field name="format">image/png</field>
+<field name="size">2371888</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33516/1/20090630_Mildred_Harris.PNG</field>
+<field name="checksum">ce19ecf39455914fb454dc1b2636bbf1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20090630_Mildred_Harris.pdf</field>
+<field name="originalName">20090630_Mildred_Harris.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">311412</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33516/2/20090630_Mildred_Harris.pdf</field>
+<field name="checksum">d3bef3b4501ed255b331a85a319db577</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090630_Mildred_Harris.PNG.jpg</field>
+<field name="originalName">20090630_Mildred_Harris.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8688</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33516/3/20090630_Mildred_Harris.PNG.jpg</field>
+<field name="checksum">ef1c07202ebeea050d63ac2171368722</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20090630_Mildred_Harris.pdf.jpg</field>
+<field name="originalName">20090630_Mildred_Harris.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8866</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33516/6/20090630_Mildred_Harris.pdf.jpg</field>
+<field name="checksum">6870bd97408f7672ace9a8e8e90ed133</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090630_Mildred_Harris.PNG.preview.jpg</field>
+<field name="originalName">20090630_Mildred_Harris.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">35999</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33516/4/20090630_Mildred_Harris.PNG.preview.jpg</field>
+<field name="checksum">558142edc5c610c97de73ab8b5975990</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090630_Mildred_Harris.pdf.txt</field>
+<field name="originalName">20090630_Mildred_Harris.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">26412</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33516/5/20090630_Mildred_Harris.pdf.txt</field>
+<field name="checksum">1a1b7ae898c98e4fed8f1581bcc3733e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33516</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33516</field>
+<field name="lastModifyDate">2018-07-27 14:20:19.784</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33522</identifier><datestamp>2018-07-27T19:21:18Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Strong, Evelyn</field>
+<field name="value">Scales, Marrissa</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T16:29:19Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T16:29:19Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2009-07-08</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33522</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20090708_Evelyn_Strong</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Evelyn Strong, part of the Hyde Park Neighborhood collection.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278576742</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Hyde Park (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Civil rights</field>
+<field name="value">Education</field>
+<field name="value">Race relations</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Evelyn Strong, 2009</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090708_Evelyn_Strong.PNG</field>
+<field name="originalName">20090708_Evelyn_Strong.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1819860</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33522/1/20090708_Evelyn_Strong.PNG</field>
+<field name="checksum">ec3cf6538e8f7f3f25abe583079af9a0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20090708_Evelyn_Strong.pdf</field>
+<field name="originalName">20090708_Evelyn_Strong.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">324757</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33522/2/20090708_Evelyn_Strong.pdf</field>
+<field name="checksum">3efc81073ee21a7ed83baf64263e936d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090708_Evelyn_Strong.PNG.jpg</field>
+<field name="originalName">20090708_Evelyn_Strong.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8881</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33522/3/20090708_Evelyn_Strong.PNG.jpg</field>
+<field name="checksum">cdb9a101d186ff2d6c8bae60895be5e5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20090708_Evelyn_Strong.pdf.jpg</field>
+<field name="originalName">20090708_Evelyn_Strong.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8439</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33522/6/20090708_Evelyn_Strong.pdf.jpg</field>
+<field name="checksum">700ca240755ea4fc912c567433766341</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090708_Evelyn_Strong.PNG.preview.jpg</field>
+<field name="originalName">20090708_Evelyn_Strong.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">37074</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33522/4/20090708_Evelyn_Strong.PNG.preview.jpg</field>
+<field name="checksum">4b6abe226e6a73ce44745e3e6ef75a42</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090708_Evelyn_Strong.pdf.txt</field>
+<field name="originalName">20090708_Evelyn_Strong.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">38272</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33522/5/20090708_Evelyn_Strong.pdf.txt</field>
+<field name="checksum">addb7712e6ad5ad508bcf4b7d91c358b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33522</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33522</field>
+<field name="lastModifyDate">2018-07-27 14:21:18.268</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33565</identifier><datestamp>2018-07-10T20:07:17Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Busby, Larry</field>
+<field name="value">Busby, Suzanne</field>
+<field name="value">Pham, Ngyuen-Huong</field>
+<field name="value">Hines, Cuyler</field>
+<field name="value">Rhynes, Anne-Chevette</field>
+<field name="value">Hughes, Paulette (Gayle)</field>
+<field name="value">Osella, Sophie</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T19:54:20Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T19:54:20Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-01-13</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33565</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130113_Larry_Suzanne_Busby</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Larry and Suzanne Busby, two of Elvis' neighbors at 1034 Audubon Drive, his residence prior to Graceland. They discuss what it was like to live near the King during his initial rise in popularity. The interview was conducted January 13th, 2013. Interviewers for this project include: Nguyen Huong Pham ('14), Cuyler Hines ('14), Anne-Chevette Rhynes ('13), Gayle Hughes ('13), and Sophia Osella ('14).</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279334797</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Music</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Presley, Elvis, 1935-1977</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Larry and Suzanne Busby, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.PNG.jpg</field>
+<field name="originalName">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7583</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33565/3/20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.PNG.jpg</field>
+<field name="checksum">dcc843ba66fc938678378aabb41fc4c3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.pdf.jpg</field>
+<field name="originalName">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6216</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33565/6/20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.pdf.jpg</field>
+<field name="checksum">d9259890b7e2f7eb32c4558be0db3635</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.PNG.preview.jpg</field>
+<field name="originalName">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">28786</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33565/4/20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.PNG.preview.jpg</field>
+<field name="checksum">e3b1f31f2ef5bf70580cf9d434a57f32</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.pdf.txt</field>
+<field name="originalName">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">8380</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33565/5/20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.pdf.txt</field>
+<field name="checksum">22936884873140c250210ab6bd0953cb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.PNG</field>
+<field name="originalName">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1103552</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33565/1/20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.PNG</field>
+<field name="checksum">9408238d0fc538c6d55c306f5d6509be</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.pdf</field>
+<field name="originalName">20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">492970</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33565/2/20130113_Elvis_Neighbors_Audubon_House_Larry_Suzanne_Busby.pdf</field>
+<field name="checksum">e2ca944094048a3acebd9f3220928d35</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33565</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33565</field>
+<field name="lastModifyDate">2018-07-10 15:07:17.48</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33579</identifier><datestamp>2018-07-17T15:22:35Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Cummings, Morris</field>
+<field name="value">Pham, Ngyuen-Huong</field>
+<field name="value">Rhynes, Anne</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-22T19:46:00Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-22T19:46:00Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2012-10-22</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33579</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20121022_Morris_Cummings</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Interview with Morris "Blind Mississippi Morris" Cummings discusses his career in Memphis and the Mississippi Delta, growing up blind and the Memphis music scene both past and contemporary. Interviewer: Anne Rhynes Date: October 22, 2012</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280382102</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Music</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Morris Cummings, 2012</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20121022_Morris_Cummings.PNG.jpg</field>
+<field name="originalName">20121022_Morris_Cummings.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11414</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33579/3/20121022_Morris_Cummings.PNG.jpg</field>
+<field name="checksum">57ec1697ddd9e3798bf3d49dafcb5f15</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20121022_Morris_Cummings.pdf.jpg</field>
+<field name="originalName">20121022_Morris_Cummings.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12444</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33579/6/20121022_Morris_Cummings.pdf.jpg</field>
+<field name="checksum">01458db0b99ae99f522ee2e76a19c203</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20121022_Morris_Cummings.PNG.preview.jpg</field>
+<field name="originalName">20121022_Morris_Cummings.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">43511</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33579/4/20121022_Morris_Cummings.PNG.preview.jpg</field>
+<field name="checksum">ed984a4c5348509fa14aeb22b8ba1333</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20121022_Morris_Cummings.pdf.txt</field>
+<field name="originalName">20121022_Morris_Cummings.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">45623</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33579/5/20121022_Morris_Cummings.pdf.txt</field>
+<field name="checksum">8c4e03f20f32f16f7139332449747feb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20121022_Morris_Cummings.PNG</field>
+<field name="originalName">20121022_Morris_Cummings.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1497189</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33579/1/20121022_Morris_Cummings.PNG</field>
+<field name="checksum">a267367f5fb2948dbb94f19272440ffd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20121022_Morris_Cummings.pdf</field>
+<field name="originalName">20121022_Morris_Cummings.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">301427</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33579/2/20121022_Morris_Cummings.pdf</field>
+<field name="checksum">c1d07b5161e7d48ee8cd00dfe99e4f98</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33579</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33579</field>
+<field name="lastModifyDate">2018-07-17 10:22:35.441</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33721</identifier><datestamp>2018-07-17T17:03:54Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Bailey, D'Army</field>
+<field name="value">Davis, Francesca</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-20T21:27:09Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-20T21:27:09Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-06-01</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33721</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20070601_DArmy_Bailey</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Born in Memphis, Judge D'Army Bailey talks about growing up in the city. He discusses difficulties black people faced in the Civil Rights era.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278554258</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Race relations</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Civil rights</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Judge D'Army Bailey, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070601_D'Army_Bailey.JPG.jpg</field>
+<field name="originalName">20070601_D'Army_Bailey.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11286</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33721/3/20070601_D%27Army_Bailey.JPG.jpg</field>
+<field name="checksum">c46741bec1cfdfdcb8b20ee7dfca6289</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070601_D'Army_Bailey.JPG.preview.jpg</field>
+<field name="originalName">20070601_D'Army_Bailey.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">48352</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33721/4/20070601_D%27Army_Bailey.JPG.preview.jpg</field>
+<field name="checksum">f3cb14c735a03a63bc4196b8809df86a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070601_D'Army_Bailey.txt.txt</field>
+<field name="originalName">20070601_D'Army_Bailey.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">83991</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33721/5/20070601_D%27Army_Bailey.txt.txt</field>
+<field name="checksum">0723ac7b5ff1954352e749bbc532b4dd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070601_D'Army_Bailey.JPG</field>
+<field name="originalName">20070601_D'Army_Bailey.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">111655</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33721/1/20070601_D%27Army_Bailey.JPG</field>
+<field name="checksum">84de8dc887ccc419d6ee89b24657cbcd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20070601_D'Army_Bailey.txt</field>
+<field name="originalName">20070601_D'Army_Bailey.txt</field>
+<field name="format">text/plain</field>
+<field name="size">89846</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33721/2/20070601_D%27Army_Bailey.txt</field>
+<field name="checksum">3d3d28d8b4aae4d739653b3911d445ba</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33721</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33721</field>
+<field name="lastModifyDate">2018-07-17 12:03:54.36</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33368</identifier><datestamp>2018-07-17T19:47:34Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">McBride, Tonya</field>
+<field name="value">Hibbert, Caroline</field>
+<field name="value">Doss, Dashauna</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:35Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:35Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-07-03</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33368</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130703_Tonya_McBride</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Interview of community member Tonya McBride from The Heights History Camp, 2013. Interviewed by Treadwell Middle students, sponsored by The Corners at Highland Heights Shalom Zone, Rhodes College, and The Center for Transforming Communities</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279543780</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Tonya McBride, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130703_Tonya_McBride.JPG.jpg</field>
+<field name="originalName">20130703_Tonya_McBride.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7300</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33368/3/20130703_Tonya_McBride.JPG.jpg</field>
+<field name="checksum">41c97cb06a9ee6083d99b02cd3287fe0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130703_Tonya_McBride.pdf.jpg</field>
+<field name="originalName">20130703_Tonya_McBride.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11165</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33368/6/20130703_Tonya_McBride.pdf.jpg</field>
+<field name="checksum">c149a11016b86230de2a9464430aaaf9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130703_Tonya_McBride.JPG.preview.jpg</field>
+<field name="originalName">20130703_Tonya_McBride.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">20752</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33368/4/20130703_Tonya_McBride.JPG.preview.jpg</field>
+<field name="checksum">84c8bdb8ab90fd93e6545c9c2fb06e0e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130703_Tonya_McBride.pdf.txt</field>
+<field name="originalName">20130703_Tonya_McBride.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">29928</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33368/5/20130703_Tonya_McBride.pdf.txt</field>
+<field name="checksum">500e63756b841332507b89f683bfc47e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130703_Tonya_McBride.JPG</field>
+<field name="originalName">20130703_Tonya_McBride.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">30057</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33368/1/20130703_Tonya_McBride.JPG</field>
+<field name="checksum">98486edb0c67b901de88353eb5a8beab</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130703_Tonya_McBride.pdf</field>
+<field name="originalName">20130703_Tonya_McBride.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">166964</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33368/2/20130703_Tonya_McBride.pdf</field>
+<field name="checksum">c998fe1c666a992adba412bf4d31443a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33368</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33368</field>
+<field name="lastModifyDate">2018-07-17 14:47:34.843</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33725</identifier><datestamp>2018-07-12T18:20:40Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Fry, John Edward</field>
+<field name="value">Perry, LaKevia</field>
+<field name="value">Eskew, Courtney</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-20T21:27:11Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-20T21:27:11Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2010-04-01</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33725</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20100401_John_Fry</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview in the Liner Notes collection, a collaboration between Crossroads and the Memphis Rock 'N' Soul Museum. John Fry, Founder of Ardent Studios, describes how he became involved in music.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278581229</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Stax records</field>
+<field name="value">Music</field>
+<field name="value">Ardent Records</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">John Fry, 2010</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100401_John_Fry.JPG</field>
+<field name="originalName">20100401_John_Fry.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">65908</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33725/1/20100401_John_Fry.JPG</field>
+<field name="checksum">6da0422dee78f072eca9e95788264277</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20100401_John_Fry.pdf</field>
+<field name="originalName">20100401_John_Fry.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">243013</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33725/2/20100401_John_Fry.pdf</field>
+<field name="checksum">b4eaf6d8d8c63d6b5242d1d0765a381a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100401_John_Fry.JPG.jpg</field>
+<field name="originalName">20100401_John_Fry.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7908</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33725/3/20100401_John_Fry.JPG.jpg</field>
+<field name="checksum">cbcaa94371df6a3d04c8a13d2c582bdf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20100401_John_Fry.pdf.jpg</field>
+<field name="originalName">20100401_John_Fry.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11849</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33725/6/20100401_John_Fry.pdf.jpg</field>
+<field name="checksum">130c14560cf80a22b0245b159662fd09</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100401_John_Fry.JPG.preview.jpg</field>
+<field name="originalName">20100401_John_Fry.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">30545</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33725/4/20100401_John_Fry.JPG.preview.jpg</field>
+<field name="checksum">7ff3889cf65e2aef897ee78e1e03e3af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100401_John_Fry.pdf.txt</field>
+<field name="originalName">20100401_John_Fry.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">59579</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33725/5/20100401_John_Fry.pdf.txt</field>
+<field name="checksum">988f65de255fee0e0098bab5fbe0ead3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33725</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33725</field>
+<field name="lastModifyDate">2018-07-12 13:20:40.035</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33609</identifier><datestamp>2018-07-17T17:46:55Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Williams, Sarah</field>
+<field name="value">McCain, Tretarius</field>
+<field name="value">Jones, Cameron</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:19Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:19Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-07-10</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33609</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130710_Sarah_Williams</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Sarah Williams. Williams is a member of Greater White Stone Missionary Baptist Church and a resident of South Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280405373</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Sarah Williams, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130710_Sarah_Williams.JPG</field>
+<field name="originalName">20130710_Sarah_Williams.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">60317</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33609/1/20130710_Sarah_Williams.JPG</field>
+<field name="checksum">2d79b48b50d2b477151ab3030df74512</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130710_Sarah_Williams.pdf</field>
+<field name="originalName">20130710_Sarah_Williams.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">181668</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33609/2/20130710_Sarah_Williams.pdf</field>
+<field name="checksum">596ae0c9920712729fbf2f9255f6cc13</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130710_Sarah_Williams.JPG.jpg</field>
+<field name="originalName">20130710_Sarah_Williams.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7626</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33609/3/20130710_Sarah_Williams.JPG.jpg</field>
+<field name="checksum">e94204fd70287be5a308c5c9bce9bb6c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130710_Sarah_Williams.pdf.jpg</field>
+<field name="originalName">20130710_Sarah_Williams.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11916</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33609/6/20130710_Sarah_Williams.pdf.jpg</field>
+<field name="checksum">a886c81bbe26455b950624b089ddcf4c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130710_Sarah_Williams.JPG.preview.jpg</field>
+<field name="originalName">20130710_Sarah_Williams.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">28264</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33609/4/20130710_Sarah_Williams.JPG.preview.jpg</field>
+<field name="checksum">4f95d869a3ad710cf99a27dd4a097da2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130710_Sarah_Williams.pdf.txt</field>
+<field name="originalName">20130710_Sarah_Williams.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">27813</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33609/5/20130710_Sarah_Williams.pdf.txt</field>
+<field name="checksum">92b04db2793446232db6636d4cb07e0c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33609</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33609</field>
+<field name="lastModifyDate">2018-07-17 12:46:55.671</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33470</identifier><datestamp>2018-07-16T17:04:51Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Parks, Daisy</field>
+<field name="value">Kimble, Cedric</field>
+<field name="value">Benson, Zahria</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-16T16:46:33Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-16T16:46:33Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2015-06-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33470</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20150619_Daisy_Parks</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Daisy Parks shares her experiences growing up in Tiptonville, Tennessee.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280197654</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Lake County (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Tiptonville (Tenn.)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Daisy Parks, 2015</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150619_Daisy_Parks.JPG</field>
+<field name="originalName">20150619_Daisy_Parks.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">49897</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33470/1/20150619_Daisy_Parks.JPG</field>
+<field name="checksum">b28b593700621e2a8465c0db82535c6a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20150619_Daisy_Parks.pdf</field>
+<field name="originalName">20150619_Daisy_Parks.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">281151</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33470/2/20150619_Daisy_Parks.pdf</field>
+<field name="checksum">d164070d63ef0bbac821d9083ce21007</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150619_Daisy_Parks.JPG.jpg</field>
+<field name="originalName">20150619_Daisy_Parks.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6689</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33470/3/20150619_Daisy_Parks.JPG.jpg</field>
+<field name="checksum">f5b759b0e6fe238ba32acd2f0e37ae22</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20150619_Daisy_Parks.pdf.jpg</field>
+<field name="originalName">20150619_Daisy_Parks.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12081</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33470/6/20150619_Daisy_Parks.pdf.jpg</field>
+<field name="checksum">83775dcd1e67640ac5291f89a548d2db</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150619_Daisy_Parks.JPG.preview.jpg</field>
+<field name="originalName">20150619_Daisy_Parks.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">24614</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33470/4/20150619_Daisy_Parks.JPG.preview.jpg</field>
+<field name="checksum">f3a5c95b60100b7c2907869ba16ce6fa</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150619_Daisy_Parks.pdf.txt</field>
+<field name="originalName">20150619_Daisy_Parks.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">14315</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33470/5/20150619_Daisy_Parks.pdf.txt</field>
+<field name="checksum">73d56086d5b1f158de5ce9fea4c0ba11</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33470</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33470</field>
+<field name="lastModifyDate">2018-07-16 12:04:51.592</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33485</identifier><datestamp>2018-07-16T17:04:51Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Holliman, Debra</field>
+<field name="value">Smith, Blaire</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-16T16:46:37Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-16T16:46:37Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-06-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33485</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140617_Debra_Holliman</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, Debra Holliman shares her experiences growing up and living in Lake County, TN as a woman of color. Interviewee: Debra Holliman Interviewer: Blaire Smith Date: June 17, 2014</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279913350</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Lake County (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Debra Holliman, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140617_Debra_Holliman.JPG.jpg</field>
+<field name="originalName">20140617_Debra_Holliman.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9042</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33485/3/20140617_Debra_Holliman.JPG.jpg</field>
+<field name="checksum">3838a781920fbdb525e204e1ed084627</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140617_Debra_Holliman.pdf.jpg</field>
+<field name="originalName">20140617_Debra_Holliman.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13689</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33485/6/20140617_Debra_Holliman.pdf.jpg</field>
+<field name="checksum">7ac6d7fa991de964be75f9565c48a75a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140617_Debra_Holliman.JPG.preview.jpg</field>
+<field name="originalName">20140617_Debra_Holliman.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">34438</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33485/4/20140617_Debra_Holliman.JPG.preview.jpg</field>
+<field name="checksum">8b5fb13a279df5545e82b4320a81248f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140617_Debra_Holliman.pdf.txt</field>
+<field name="originalName">20140617_Debra_Holliman.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">19986</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33485/5/20140617_Debra_Holliman.pdf.txt</field>
+<field name="checksum">f530619b45a2df2d765d504dde46f4f6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140617_Debra_Holliman.JPG</field>
+<field name="originalName">20140617_Debra_Holliman.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">71889</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33485/1/20140617_Debra_Holliman.JPG</field>
+<field name="checksum">e5a2b3d79acab4b79f32f992d63d240a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140617_Debra_Holliman.pdf</field>
+<field name="originalName">20140617_Debra_Holliman.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">442719</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33485/2/20140617_Debra_Holliman.pdf</field>
+<field name="checksum">d4642a9f70a8e4c8517f13e8fe76b92d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33485</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33485</field>
+<field name="lastModifyDate">2018-07-16 12:04:51.734</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33619</identifier><datestamp>2018-07-17T19:46:26Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Doss, Booker</field>
+<field name="value">Boone, Damesha</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:20Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:20Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-07-02</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33619</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140702_Booker_Doss</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, Mr. Doss shares his experiences growing up in Mississippi and later living in South Memphis. Mr. Doss is a faithful member of Greater Whitestone Missionary Baptist Church.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279680481</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Mississippi</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Booker Doss, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140702_Booker_Doss.JPG.jpg</field>
+<field name="originalName">20140702_Booker_Doss.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">4667</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33619/3/20140702_Booker_Doss.JPG.jpg</field>
+<field name="checksum">be71282f8222045e92af81edd722aab0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140702_Booker_Doss.pdf.jpg</field>
+<field name="originalName">20140702_Booker_Doss.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11131</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33619/6/20140702_Booker_Doss.pdf.jpg</field>
+<field name="checksum">7f8eccd91621e5062fd68d1189cb2d9b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140702_Booker_Doss.JPG.preview.jpg</field>
+<field name="originalName">20140702_Booker_Doss.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">18763</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33619/4/20140702_Booker_Doss.JPG.preview.jpg</field>
+<field name="checksum">b6ed15e5e8589639c6fd3012f281bc2c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140702_Booker_Doss.pdf.txt</field>
+<field name="originalName">20140702_Booker_Doss.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">21739</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33619/5/20140702_Booker_Doss.pdf.txt</field>
+<field name="checksum">b1e50d1b78f2acceabb3c2eb0d00d167</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140702_Booker_Doss.JPG</field>
+<field name="originalName">20140702_Booker_Doss.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">41675</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33619/1/20140702_Booker_Doss.JPG</field>
+<field name="checksum">f2cbda956495800efee5ae1d48ed2306</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140702_Booker_Doss.pdf</field>
+<field name="originalName">20140702_Booker_Doss.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">253654</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33619/2/20140702_Booker_Doss.pdf</field>
+<field name="checksum">fa48a4379f82dd5697bd3a9d1ac820d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33619</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33619</field>
+<field name="lastModifyDate">2018-07-17 14:46:26.582</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33498</identifier><datestamp>2018-07-27T16:36:05Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Short, Bill</field>
+<field name="value">Jeffries, Joshua</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T15:23:58Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T15:23:58Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-07-27</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33498</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20070727_Bill_Short</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Bill Short, who is currently the Archivist for the Rhodes College Library. He recounts his experiences growing up in a small, rural farming community during segregation. Furthermore, he describes the tensions of racial integration on the campus of Rhodes Colleges when he was a student in the 1960's. Mr. Short relates how he worked at the personal level to increase tolerance and understanding while in college and now.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278558000</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Civil rights</field>
+<field name="value">Education</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Race relations</field>
+<field name="value">Jim Crow, 1890-1976</field>
+<field name="value">Sanitation Workers Strike, Memphis, Tenn., 1968</field>
+<field name="value">Rhodes College (Memphis, Tenn.)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Bill Short, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070727_Bill_Short.JPG</field>
+<field name="originalName">20070727_Bill_Short.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">51247</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33498/1/20070727_Bill_Short.JPG</field>
+<field name="checksum">eea7caf34ffed4d6bae6b5a25f1d7518</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20070727_Bill_Short.pdf</field>
+<field name="originalName">20070727_Bill_Short.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">394300</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33498/2/20070727_Bill_Short.pdf</field>
+<field name="checksum">2adcc830340ff6fa1d1cb10305a0973c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070727_Bill_Short.JPG.jpg</field>
+<field name="originalName">20070727_Bill_Short.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11956</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33498/3/20070727_Bill_Short.JPG.jpg</field>
+<field name="checksum">29e821a7ee892a6d70f82eae6b349b50</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20070727_Bill_Short.pdf.jpg</field>
+<field name="originalName">20070727_Bill_Short.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9776</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33498/6/20070727_Bill_Short.pdf.jpg</field>
+<field name="checksum">17d2b24b497b3c86780b2296c2593a9c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070727_Bill_Short.JPG.preview.jpg</field>
+<field name="originalName">20070727_Bill_Short.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">35931</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33498/4/20070727_Bill_Short.JPG.preview.jpg</field>
+<field name="checksum">f32634a0a6ef84be5871807803262285</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070727_Bill_Short.pdf.txt</field>
+<field name="originalName">20070727_Bill_Short.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">66635</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33498/5/20070727_Bill_Short.pdf.txt</field>
+<field name="checksum">ea1f2bbace63af91ba65baf20125e506</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33498</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33498</field>
+<field name="lastModifyDate">2018-07-27 11:36:05.459</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33364</identifier><datestamp>2018-08-01T20:03:50Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Morgan, Ricky</field>
+<field name="value">Holmes Jr, Kerwin</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:34Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:34Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-06-26</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33364</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130626_Ric_Morgan</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Ricky Morgan, parishioner  of the Highland Heights United Methodist Church, shares his insight on the Highland Heights neighborhood in Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279542136</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Ric Morgan, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_Ric_Morgan.PNG</field>
+<field name="originalName">20130626_Ric_Morgan.PNG</field>
+<field name="format">image/png</field>
+<field name="size">170217</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33364/1/20130626_Ric_Morgan.PNG</field>
+<field name="checksum">840fa6f432add5af265cd67945f10c75</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_Ric_Morgan.pdf</field>
+<field name="originalName">20130626_Ric_Morgan.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">168759</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33364/2/20130626_Ric_Morgan.pdf</field>
+<field name="checksum">fb364e3896cd7dcf7a3f35b36fe85abb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.PNG.jpg</field>
+<field name="originalName">Capture.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7786</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33364/3/Capture.PNG.jpg</field>
+<field name="checksum">4620135258dfc4209de237ec0d30f5c5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_Ric_Morgan.pdf.jpg</field>
+<field name="originalName">20130626_Ric_Morgan.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13195</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33364/6/20130626_Ric_Morgan.pdf.jpg</field>
+<field name="checksum">65eea51e99972c5c6de7d3ee8332dd13</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_Ric_Morgan.PNG.jpg</field>
+<field name="originalName">20130626_Ric_Morgan.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7786</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33364/7/20130626_Ric_Morgan.PNG.jpg</field>
+<field name="checksum">4620135258dfc4209de237ec0d30f5c5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.PNG.preview.jpg</field>
+<field name="originalName">Capture.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">12268</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33364/4/Capture.PNG.preview.jpg</field>
+<field name="checksum">756c61c4e10eb854f570c0dba586b4f4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_Ric_Morgan.PNG.preview.jpg</field>
+<field name="originalName">20130626_Ric_Morgan.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">12268</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33364/8/20130626_Ric_Morgan.PNG.preview.jpg</field>
+<field name="checksum">756c61c4e10eb854f570c0dba586b4f4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_Ric_Morgan.pdf.txt</field>
+<field name="originalName">20130626_Ric_Morgan.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">27126</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33364/5/20130626_Ric_Morgan.pdf.txt</field>
+<field name="checksum">16f7cbac1875da6956b14e27e3228840</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33364</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33364</field>
+<field name="lastModifyDate">2018-08-01 15:03:50.696</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33546</identifier><datestamp>2018-07-20T17:15:08Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Mercer, Charles</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T15:16:02Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T15:16:02Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2006-05-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33546</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20060519_Charles_Mercer</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Christopher Mercer, a lawyer. He tells his feelings on a particular fearful situation in his life while fighting for Civil Rights. He also explains the importance of collecting stories into archives.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278534752</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Law</field>
+<field name="value">Sanitation Workers Strike, Memphis, Tenn., 1968</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Charles Mercer, 2006</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20060519_Charles_Mercer.jpg</field>
+<field name="originalName">20060519_Charles_Mercer.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">256344</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33546/1/20060519_Charles_Mercer.jpg</field>
+<field name="checksum">d881abfefa2629e3c214b543cd45ce5c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20060519_Charles_Mercer.pdf</field>
+<field name="originalName">20060519_Charles_Mercer.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">242849</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33546/2/20060519_Charles_Mercer.pdf</field>
+<field name="checksum">c0796c4daa0991068dd34b7d9a80bbde</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20060519_Charles_Mercer.jpg.jpg</field>
+<field name="originalName">20060519_Charles_Mercer.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">16291</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33546/3/20060519_Charles_Mercer.jpg.jpg</field>
+<field name="checksum">9a3c55611ccc29b1f9a6a02b6bc1e374</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20060519_Charles_Mercer.pdf.jpg</field>
+<field name="originalName">20060519_Charles_Mercer.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12358</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33546/6/20060519_Charles_Mercer.pdf.jpg</field>
+<field name="checksum">66cb5c38fecb1fca7fbeded2113b7ca7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20060519_Charles_Mercer.jpg.preview.jpg</field>
+<field name="originalName">20060519_Charles_Mercer.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">63933</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33546/4/20060519_Charles_Mercer.jpg.preview.jpg</field>
+<field name="checksum">e345df031cacba25d7945231bc88044b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20060519_Charles_Mercer.pdf.txt</field>
+<field name="originalName">20060519_Charles_Mercer.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">50583</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33546/5/20060519_Charles_Mercer.pdf.txt</field>
+<field name="checksum">154feb99c727a61d3aae0b712f6cfe48</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33546</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33546</field>
+<field name="lastModifyDate">2018-07-20 12:15:08.098</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33622</identifier><datestamp>2018-07-16T17:04:51Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Lacy, Patricia</field>
+<field name="value">Boone, Damesha</field>
+<field name="value">Miller, Rodtavis</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:21Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:21Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-07-09</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33622</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140709_Patricia_Lacy</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Patricia Lacey. Born in North Carolina, this talented musician  has long been member of the South Memphis Community.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279685180</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Music</field>
+<field name="value">North Carolina</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Patricia Lacy, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140709_Patricia_Lacy.JPG</field>
+<field name="originalName">20140709_Patricia_Lacy.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">41376</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33622/1/20140709_Patricia_Lacy.JPG</field>
+<field name="checksum">d1e8a3dccb7e67815ee8a6a4dd571cb3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140709_Patricia_Lacy.pdf</field>
+<field name="originalName">20140709_Patricia_Lacy.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">253250</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33622/2/20140709_Patricia_Lacy.pdf</field>
+<field name="checksum">5876c24c75ba10c042394d1361c52a2f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140709_Patricia_Lacy.JPG.jpg</field>
+<field name="originalName">20140709_Patricia_Lacy.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">5146</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33622/3/20140709_Patricia_Lacy.JPG.jpg</field>
+<field name="checksum">864e9aa56285c40234275abd9738a1d5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140709_Patricia_Lacy.pdf.jpg</field>
+<field name="originalName">20140709_Patricia_Lacy.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12397</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33622/6/20140709_Patricia_Lacy.pdf.jpg</field>
+<field name="checksum">ae8c9953714c92c94b297003c325529a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140709_Patricia_Lacy.JPG.preview.jpg</field>
+<field name="originalName">20140709_Patricia_Lacy.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">18332</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33622/4/20140709_Patricia_Lacy.JPG.preview.jpg</field>
+<field name="checksum">ea77d252f39ebb9246f7f98f472273a5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140709_Patricia_Lacy.pdf.txt</field>
+<field name="originalName">20140709_Patricia_Lacy.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">67882</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33622/5/20140709_Patricia_Lacy.pdf.txt</field>
+<field name="checksum">f9b900ed244a4f14796f1107f0c2aaf9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33622</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33622</field>
+<field name="lastModifyDate">2018-07-16 12:04:51.96</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33396</identifier><datestamp>2018-07-17T20:35:07Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Khan, Shan</field>
+<field name="value">Khan, Irem</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-01T15:16:32Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-01T15:16:32Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-07-17</field>
+</element>
+</element>
+<element name="graduation">
+<element name="none">
+<field name="value">2014</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33396</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140717_Shan_Khan</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Collection: Islam in Memphis Oral Histories, Interviewees: Shan Khan, Interviewer: Irem Khan, Date: 2014-07-17</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280431545</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Islam</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Shan Khan, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140717_Shan_Khan</field>
+<field name="originalName">20140717_Shan_Khan</field>
+<field name="format">image/jpeg</field>
+<field name="size">24708</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33396/1/20140717_Shan_Khan</field>
+<field name="checksum">43ba6f4193362c56eecc1d0468ab240d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140717_Shan_Khan.pdf</field>
+<field name="originalName">20140717_Shan_Khan.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">185539</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33396/2/20140717_Shan_Khan.pdf</field>
+<field name="checksum">7b6504659fa86547968d7bd64f8be639</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.JPG.jpg</field>
+<field name="originalName">Capture.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8254</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33396/3/Capture.JPG.jpg</field>
+<field name="checksum">15f4b3b36c62898cc37cd55efe1f20bb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140717_Shan_Khan.pdf.jpg</field>
+<field name="originalName">20140717_Shan_Khan.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12711</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33396/6/20140717_Shan_Khan.pdf.jpg</field>
+<field name="checksum">c45f62cbae456de57e7b002261e05422</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20140717_Shan_Khan.jpg</field>
+<field name="originalName">20140717_Shan_Khan.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8254</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33396/7/20140717_Shan_Khan.jpg</field>
+<field name="checksum">15f4b3b36c62898cc37cd55efe1f20bb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.JPG.preview.jpg</field>
+<field name="originalName">Capture.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">15080</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33396/4/Capture.JPG.preview.jpg</field>
+<field name="checksum">4985a0179958f9e5b7be380ba6b835fc</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20140717_Shan_Khan.preview.jpg</field>
+<field name="originalName">20140717_Shan_Khan.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">15080</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33396/8/20140717_Shan_Khan.preview.jpg</field>
+<field name="checksum">4985a0179958f9e5b7be380ba6b835fc</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140717_Shan_Khan.pdf.txt</field>
+<field name="originalName">20140717_Shan_Khan.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">41338</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33396/5/20140717_Shan_Khan.pdf.txt</field>
+<field name="checksum">3de3dcb9d86d220d294bb3481318b792</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33396</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33396</field>
+<field name="lastModifyDate">2018-07-17 15:35:07.661</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33689</identifier><datestamp>2018-07-16T21:30:07Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Maclin, Mary</field>
+<field name="value">Murray, Missy</field>
+<field name="value">Taylor, Ashleigh</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-04T18:01:12Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-04T18:01:12Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2010-06-18</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33689</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20100618_Mary_Maclin</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Mary Maclin. She was one of the first black cheerleaders at Northside High School.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280264654</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Evergreen Historic District (Memphis, Tenn.)</field>
+<field name="value">School integration</field>
+<field name="value">African Americans</field>
+</element>
+<element name="none">
+<field name="value">Education</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Mary Maclin, 2010</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100618_Mary_Maclin.JPG</field>
+<field name="originalName">20100618_Mary_Maclin.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">101575</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33689/1/20100618_Mary_Maclin.JPG</field>
+<field name="checksum">0b49bb04a9068307b75082d67f213351</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20100618_Mary_Maclin.pdf</field>
+<field name="originalName">20100618_Mary_Maclin.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">210991</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33689/2/20100618_Mary_Maclin.pdf</field>
+<field name="checksum">270ee1c4087e50cedd17a90522e213d8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100618_Mary_Maclin.JPG.jpg</field>
+<field name="originalName">20100618_Mary_Maclin.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11939</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33689/3/20100618_Mary_Maclin.JPG.jpg</field>
+<field name="checksum">76d06118a466c3bf09e193d1979916c9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20100618_Mary_Maclin.pdf.jpg</field>
+<field name="originalName">20100618_Mary_Maclin.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13571</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33689/6/20100618_Mary_Maclin.pdf.jpg</field>
+<field name="checksum">b50df5bed411426407a2ecd025ba1c95</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100618_Mary_Maclin.JPG.preview.jpg</field>
+<field name="originalName">20100618_Mary_Maclin.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">45977</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33689/4/20100618_Mary_Maclin.JPG.preview.jpg</field>
+<field name="checksum">0e65a18117594188d741caaea018c32a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20100618_Mary_Maclin.pdf.txt</field>
+<field name="originalName">20100618_Mary_Maclin.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">49433</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33689/5/20100618_Mary_Maclin.pdf.txt</field>
+<field name="checksum">4ac01f597224662304ba381846901747</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33689</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33689</field>
+<field name="lastModifyDate">2018-07-16 16:30:07.611</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33610</identifier><datestamp>2018-10-17T16:25:57Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Bates, Willie</field>
+<field name="value">Smith, Malishia</field>
+<field name="value">McCain, Tretarius</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:19Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:19Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-07-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33610</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130717_Willie_Bates</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Willie Bates. Bates, owner of The Four Way Grill who grew up in South Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280408092</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Restaurants</field>
+<field name="value">The Four Way Soul Food Restaurant (Memphis, Tenn.)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Willie Bates, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130717_Willie_Bates.JPG.jpg</field>
+<field name="originalName">20130717_Willie_Bates.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6616</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33610/3/20130717_Willie_Bates.JPG.jpg</field>
+<field name="checksum">17aadfec15e17c470ca4f9b7f5d1b96b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130717_Willie_Bates.pdf.jpg</field>
+<field name="originalName">20130717_Willie_Bates.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12083</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33610/6/20130717_Willie_Bates.pdf.jpg</field>
+<field name="checksum">0ff5cea7790bc1defe8bee91837c900e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130717_Willie_Bates.JPG.preview.jpg</field>
+<field name="originalName">20130717_Willie_Bates.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">23977</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33610/4/20130717_Willie_Bates.JPG.preview.jpg</field>
+<field name="checksum">6c9d9608d08e26831887866dc1e13b20</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130717_Willie_Bates.pdf.txt</field>
+<field name="originalName">20130717_Willie_Bates.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">28488</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33610/5/20130717_Willie_Bates.pdf.txt</field>
+<field name="checksum">ef9055998b13a838d78099d104588ca2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130717_Willie_Bates.JPG</field>
+<field name="originalName">20130717_Willie_Bates.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">52709</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33610/1/20130717_Willie_Bates.JPG</field>
+<field name="checksum">72a1338377b62920f28f3ae37fcaf7cc</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130717_Willie_Bates.pdf</field>
+<field name="originalName">20130717_Willie_Bates.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">173417</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33610/2/20130717_Willie_Bates.pdf</field>
+<field name="checksum">28d1c9ef4126a682a9f7c9f095a4dee4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33610</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33610</field>
+<field name="lastModifyDate">2018-10-17 11:25:57.868</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33626</identifier><datestamp>2018-08-01T20:50:18Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Young, Steven</field>
+<field name="value">Jaranika</field>
+<field name="value">Patterson, Romeo</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:21Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:21Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2015-07-01</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33626</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20150701_Steven_Young</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this intwerview Steven Youngs talks about his life in South Memphis. He highlights the importance of music and history.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279688141</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Music</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Steven Young, 2015</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150701_Steven_Young.JPG</field>
+<field name="originalName">20150701_Steven_Young.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">67633</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33626/1/20150701_Steven_Young.JPG</field>
+<field name="checksum">24101a2ec853af6b77fc216fc6fc4e9c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20150701_Steven_Young.pdf</field>
+<field name="originalName">20150701_Steven_Young.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">136937</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33626/2/20150701_Steven_Young.pdf</field>
+<field name="checksum">e88b4f8603e49ccc6f82899b00eacacd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150701_Steven_Young.JPG.jpg</field>
+<field name="originalName">20150701_Steven_Young.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7335</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33626/3/20150701_Steven_Young.JPG.jpg</field>
+<field name="checksum">572abc295b754274a602c7808b1e4535</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20150701_Steven_Young.pdf.jpg</field>
+<field name="originalName">20150701_Steven_Young.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10717</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33626/6/20150701_Steven_Young.pdf.jpg</field>
+<field name="checksum">6924d14481782e6ff3dc8ef0c55f0abd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150701_Steven_Young.JPG.preview.jpg</field>
+<field name="originalName">20150701_Steven_Young.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">29147</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33626/4/20150701_Steven_Young.JPG.preview.jpg</field>
+<field name="checksum">74b4fde0ac28aa23288ae6129d88a360</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150701_Steven_Young.pdf.txt</field>
+<field name="originalName">20150701_Steven_Young.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">9593</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33626/5/20150701_Steven_Young.pdf.txt</field>
+<field name="checksum">a643b9e0bd9df66117d49bee15d182b5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33626</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33626</field>
+<field name="lastModifyDate">2018-08-01 15:50:18.872</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33590</identifier><datestamp>2018-07-12T18:20:40Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Stiles, Allen</field>
+<field name="value">Madjlesi, Ace</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-23T18:43:19Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-23T18:43:19Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2011-06-29</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33590</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20110629_Allen_Stiles</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Allen Stiles. Mr. Stiles talks about his parents, his childhood in Memphis, his careers and his involvement in the Civil Rights Movement, especially the sit-ins. Particularly, he recounts his first time participating in an integration in Pink Palace Museum in addition to his air-force experiences after that. Eventually, he expresses his opinions upon what changes have taken place in Memphis from the rise of Civil Rights Movement to present, and his advice to young Memphians also. Interviewee: Allen Stiles Interviewer: Ace Madjlesi Date: June 29, 2011</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278584333</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Neighborhood Histories</field>
+<field name="value">Civil rights</field>
+<field name="value">Memphis Pink Palace Museum</field>
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Allen Stiles, 2011</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110629_Allen_Stiles.PNG.jpg</field>
+<field name="originalName">20110629_Allen_Stiles.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">5399</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33590/3/20110629_Allen_Stiles.PNG.jpg</field>
+<field name="checksum">3bb1d20ea2a6f5d3511e093f9b433559</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20110629_Allen_Stiles.pdf.jpg</field>
+<field name="originalName">20110629_Allen_Stiles.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9001</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33590/6/20110629_Allen_Stiles.pdf.jpg</field>
+<field name="checksum">a63b8d1d4bb1e3c3dd0cddb43d3dd441</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110629_Allen_Stiles.PNG</field>
+<field name="originalName">20110629_Allen_Stiles.PNG</field>
+<field name="format">image/png</field>
+<field name="size">696289</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33590/1/20110629_Allen_Stiles.PNG</field>
+<field name="checksum">481f1bcd6fb007c860fff4df31bfd2ef</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20110629_Allen_Stiles.pdf</field>
+<field name="originalName">20110629_Allen_Stiles.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">321683</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33590/2/20110629_Allen_Stiles.pdf</field>
+<field name="checksum">845d19633c6f880c02012621ebbfcff7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110629_Allen_Stiles.PNG.preview.jpg</field>
+<field name="originalName">20110629_Allen_Stiles.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">22602</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33590/4/20110629_Allen_Stiles.PNG.preview.jpg</field>
+<field name="checksum">056876a8b1bfb9f70b640cf7d338c8f6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110629_Allen_Stiles.pdf.txt</field>
+<field name="originalName">20110629_Allen_Stiles.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">40015</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33590/5/20110629_Allen_Stiles.pdf.txt</field>
+<field name="checksum">c450906cc67fc5aa71984f3b355d7d0c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33590</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33590</field>
+<field name="lastModifyDate">2018-07-12 13:20:40.167</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33714</identifier><datestamp>2018-07-20T17:18:04Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">McKee, Francesca</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-12T15:31:03Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-12T15:31:03Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2017-10-28</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33714</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20171028_Francesca_McKee</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Alumna Francesca McKee ('08) discusses her time with Crossroads to Freedom during at the 10th anniversary of Crossroads during Homecoming 2017.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280970690</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Rhodes College</field>
+<field name="value">Class of 2008</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Francesca McKee, 2017</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20171028_Francesca_McKee.JPG.jpg</field>
+<field name="originalName">20171028_Francesca_McKee.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7410</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33714/3/20171028_Francesca_McKee.JPG.jpg</field>
+<field name="checksum">0c4d041e59cad4379f710ef5b2dd871c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20171028_Francesca_Mckee.pdf.jpg</field>
+<field name="originalName">20171028_Francesca_Mckee.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6114</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33714/6/20171028_Francesca_Mckee.pdf.jpg</field>
+<field name="checksum">4dd93bfc71ea71ac27bfc597ee4e19a4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20171028_Francesca_McKee.JPG.preview.jpg</field>
+<field name="originalName">20171028_Francesca_McKee.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">27256</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33714/4/20171028_Francesca_McKee.JPG.preview.jpg</field>
+<field name="checksum">27667b6e6d6f57c1d95ddb05a0e96c41</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20171028_Francesca_Mckee.pdf.txt</field>
+<field name="originalName">20171028_Francesca_Mckee.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6261</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33714/5/20171028_Francesca_Mckee.pdf.txt</field>
+<field name="checksum">2da43da7e8c805b7d436f4048a4d54ad</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20171028_Francesca_McKee.JPG</field>
+<field name="originalName">20171028_Francesca_McKee.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">61662</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33714/1/20171028_Francesca_McKee.JPG</field>
+<field name="checksum">810fa937ab1d6ac1f640117c005f6bcb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20171028_Francesca_Mckee.pdf</field>
+<field name="originalName">20171028_Francesca_Mckee.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">212964</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33714/2/20171028_Francesca_Mckee.pdf</field>
+<field name="checksum">a88c1a2a7a791b927a1ec83a395ada4f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33714</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33714</field>
+<field name="lastModifyDate">2018-07-20 12:18:04.694</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33537</identifier><datestamp>2018-07-17T17:10:33Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Selvidge, Steve</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T14:48:49Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T14:48:49Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-07-09</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33537</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130709_Steve_Selvidge</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, Steve Selvidge details how Memphis impacted his musical experience and career. Interview conducted on July 9, 2013.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280400883</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Music</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Steve Selvidge, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130709_Steve_Selvidge.PNG</field>
+<field name="originalName">20130709_Steve_Selvidge.PNG</field>
+<field name="format">image/png</field>
+<field name="size">2725901</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33537/1/20130709_Steve_Selvidge.PNG</field>
+<field name="checksum">745d67f811d5b8de5af764640bc4d302</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130709_Steve_Selvidge.pdf</field>
+<field name="originalName">20130709_Steve_Selvidge.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">310652</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33537/2/20130709_Steve_Selvidge.pdf</field>
+<field name="checksum">da42d66e51c0c7e3e6846a47921cb6cb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130709_Steve_Selvidge.PNG.jpg</field>
+<field name="originalName">20130709_Steve_Selvidge.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11358</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33537/3/20130709_Steve_Selvidge.PNG.jpg</field>
+<field name="checksum">7ab863866e8d4904b81570778e4341d2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130709_Steve_Selvidge.pdf.jpg</field>
+<field name="originalName">20130709_Steve_Selvidge.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12573</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33537/6/20130709_Steve_Selvidge.pdf.jpg</field>
+<field name="checksum">83f18cd94e36c6d9abb8b633e73131b2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130709_Steve_Selvidge.PNG.preview.jpg</field>
+<field name="originalName">20130709_Steve_Selvidge.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">47102</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33537/4/20130709_Steve_Selvidge.PNG.preview.jpg</field>
+<field name="checksum">971a2b3f3f7b96df320f28e20ba806d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130709_Steve_Selvidge.pdf.txt</field>
+<field name="originalName">20130709_Steve_Selvidge.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">49141</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33537/5/20130709_Steve_Selvidge.pdf.txt</field>
+<field name="checksum">fa1b9e04bdfb32d9a1ba7f9f771a9c04</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33537</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33537</field>
+<field name="lastModifyDate">2018-07-17 12:10:33.773</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31285</identifier><datestamp>2018-07-16T19:30:33Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Rabinbach, Jacob</field>
+<field name="value">Pitts, Charles (Skip)</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-01-17T22:05:12Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-01-17T22:05:12Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2004-08-26</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31285</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20040826_Charles_Skip_Pitts</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Charles "Skip" Pitts conducted by Jacob Rabinbach. Charles Pitts was an American soul and blues guitarist. He is best known for his distinctive "wah-wah" style, prominently featured on Isaac Hayes' title track from the 1971 movie Shaft. He is widely considered to have been one of the architects of soul, R&amp;B and funk guitar.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280244362</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Music</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Stax Records</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Charles "Skip" Pitts, 2004</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040826_Charles_Skip_Pitts.jpg</field>
+<field name="originalName">20040826_Charles_Skip_Pitts.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">78215</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31285/1/20040826_Charles_Skip_Pitts.jpg</field>
+<field name="checksum">0342a0cab8effe8ba2e88851710c039d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20040826_Charles_Skip_Pitts.pdf</field>
+<field name="originalName">20040826_Charles_Skip_Pitts.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">92722</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31285/2/20040826_Charles_Skip_Pitts.pdf</field>
+<field name="checksum">0425404c95bbe551ad2e35dd6d6e2785</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040826_Charles_Skip_Pitts.jpg.jpg</field>
+<field name="originalName">20040826_Charles_Skip_Pitts.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7676</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31285/3/20040826_Charles_Skip_Pitts.jpg.jpg</field>
+<field name="checksum">7b7cc8b572044b16dffff7a2e8cde27d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20040826_Charles_Skip_Pitts.pdf.jpg</field>
+<field name="originalName">20040826_Charles_Skip_Pitts.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10947</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31285/5/20040826_Charles_Skip_Pitts.pdf.jpg</field>
+<field name="checksum">019938377e949306dfb99bebd0785132</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040826_Charles_Skip_Pitts.pdf.txt</field>
+<field name="originalName">20040826_Charles_Skip_Pitts.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">57119</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31285/4/20040826_Charles_Skip_Pitts.pdf.txt</field>
+<field name="checksum">d4a0792ce8396cc1f2105a670c8c3bdd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040826_Charles_Skip_Pitts.jpg.preview.jpg</field>
+<field name="originalName">20040826_Charles_Skip_Pitts.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">28135</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31285/6/20040826_Charles_Skip_Pitts.jpg.preview.jpg</field>
+<field name="checksum">0e3e4a00c7bcbecdd8d3c4160ed47004</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31285</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31285</field>
+<field name="lastModifyDate">2018-07-16 14:30:33.107</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33602</identifier><datestamp>2018-07-17T19:42:29Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Downey, William</field>
+<field name="value">Crump, Mikia</field>
+<field name="value">Smith, Malishia</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:17Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:17Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-06-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33602</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130619_William_Downey</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Memphis native William Downey shares his experiences growing up and living in South Memphis. Downey works for Knowledge Quest, which is located in South Memphis, and he coaches the Knowledge Quest baseball team.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279550014</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Sports</field>
+<field name="value">Baseball</field>
+<field name="value">Nonprofit organizations</field>
+<field name="value">Knowledge Quest (Memphis, Tenn.)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">William Downey, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130619_William_Downey.JPG</field>
+<field name="originalName">20130619_William_Downey.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">47079</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33602/1/20130619_William_Downey.JPG</field>
+<field name="checksum">eea0f494b96a68ab104765e6fa4ee835</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130619_William_Downey.pdf</field>
+<field name="originalName">20130619_William_Downey.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">170414</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33602/2/20130619_William_Downey.pdf</field>
+<field name="checksum">5d8f1196ee3d6e46fe6b27aa0473ef6b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130619_William_Downey.JPG.jpg</field>
+<field name="originalName">20130619_William_Downey.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">5822</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33602/3/20130619_William_Downey.JPG.jpg</field>
+<field name="checksum">cccf8c8ea4f40ade344f8d76be3ad4eb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130619_William_Downey.pdf.jpg</field>
+<field name="originalName">20130619_William_Downey.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12175</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33602/6/20130619_William_Downey.pdf.jpg</field>
+<field name="checksum">37fd1fdcafa63d04971656fd381d0063</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130619_William_Downey.JPG.preview.jpg</field>
+<field name="originalName">20130619_William_Downey.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">22312</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33602/4/20130619_William_Downey.JPG.preview.jpg</field>
+<field name="checksum">55921908ae704ab775e1e510b131f332</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130619_William_Downey.pdf.txt</field>
+<field name="originalName">20130619_William_Downey.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">22283</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33602/5/20130619_William_Downey.pdf.txt</field>
+<field name="checksum">080ebfc9f6a74be84988c24cd4a562ff</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33602</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33602</field>
+<field name="lastModifyDate">2018-07-17 14:42:29.595</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33652</identifier><datestamp>2018-07-12T18:20:40Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Walters, Jane</field>
+<field name="value">James, Holly</field>
+<field name="value">Chesnutt, Dara</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T20:59:21Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T20:59:21Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2008-06-05</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33652</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20080605_Jane_Walters</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Ms. Jane Walters, the current principal of the Grizzlies Academy in Memphis. Walters worked as a teacher in the Memphis City School System during the Civil rights movement and she discusses her experiences with integration and its relation to education.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="none">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278565354</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Segregation</field>
+<field name="value">Education</field>
+<field name="value">Memphis City Schools</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Integration</field>
+<field name="value">Memphis Grizzlies Preparatory Charter School</field>
+<field name="value">Race relations</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Jane Walters, 2008</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080605_Jane_Walters.JPG</field>
+<field name="originalName">20080605_Jane_Walters.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">58748</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33652/1/20080605_Jane_Walters.JPG</field>
+<field name="checksum">6c0b65ba528f22d5ecd384b68460b657</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20080605_Jane_Walters.pdf</field>
+<field name="originalName">20080605_Jane_Walters.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">325116</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33652/2/20080605_Jane_Walters.pdf</field>
+<field name="checksum">7739a127e461c04eeb0ce75f4f111eac</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080605_Jane_Walters.JPG.jpg</field>
+<field name="originalName">20080605_Jane_Walters.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10369</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33652/3/20080605_Jane_Walters.JPG.jpg</field>
+<field name="checksum">28776ce91a36c355ac5341f6716f200a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20080605_Jane_Walters.pdf.jpg</field>
+<field name="originalName">20080605_Jane_Walters.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11154</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33652/6/20080605_Jane_Walters.pdf.jpg</field>
+<field name="checksum">7d17ba83048b7cb89a8545e0eccc86a3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080605_Jane_Walters.JPG.preview.jpg</field>
+<field name="originalName">20080605_Jane_Walters.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">36726</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33652/4/20080605_Jane_Walters.JPG.preview.jpg</field>
+<field name="checksum">0ba2ae88e67ed956ffcc28de203f907f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080605_Jane_Walters.pdf.txt</field>
+<field name="originalName">20080605_Jane_Walters.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">33148</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33652/5/20080605_Jane_Walters.pdf.txt</field>
+<field name="checksum">491a46cfee1fdbb3bb973142b6616de2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33652</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33652</field>
+<field name="lastModifyDate">2018-07-12 13:20:40.247</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31293</identifier><datestamp>2018-07-16T17:04:52Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Knight, Frederick</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-01-17T22:05:14Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-01-17T22:05:14Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2004-09-24</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31293</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20040924_Frederick_Knight</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Collection: Stax Oral Histories Interviewee: Frederick Knight Interviewer: unknown</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279730089</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Music</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Stax Records</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Frederick Knight, 2004</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040924_Frederick_Knight.jpg</field>
+<field name="originalName">20040924_Frederick_Knight.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">60774</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31293/1/20040924_Frederick_Knight.jpg</field>
+<field name="checksum">1ddc477416ebf68a867475a3bdab191f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20040924_Frederick_Knight.pdf</field>
+<field name="originalName">20040924_Frederick_Knight.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">146219</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31293/2/20040924_Frederick_Knight.pdf</field>
+<field name="checksum">351ebbcc4d47066ae979d555c4153b76</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040924_Frederick_Knight.jpg.jpg</field>
+<field name="originalName">20040924_Frederick_Knight.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8000</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31293/3/20040924_Frederick_Knight.jpg.jpg</field>
+<field name="checksum">dc1dbfe41c0733c19faa73776ec3acaa</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20040924_Frederick_Knight.pdf.jpg</field>
+<field name="originalName">20040924_Frederick_Knight.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7938</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31293/5/20040924_Frederick_Knight.pdf.jpg</field>
+<field name="checksum">60628e137506e1574295f6760d575763</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040924_Frederick_Knight.pdf.txt</field>
+<field name="originalName">20040924_Frederick_Knight.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">21763</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31293/4/20040924_Frederick_Knight.pdf.txt</field>
+<field name="checksum">f99f6997a50b553b7d0615d0af91a51c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040924_Frederick_Knight.jpg.preview.jpg</field>
+<field name="originalName">20040924_Frederick_Knight.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">29815</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31293/6/20040924_Frederick_Knight.jpg.preview.jpg</field>
+<field name="checksum">52de38045dae7452d283359ee0bc95b1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31293</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31293</field>
+<field name="lastModifyDate">2018-07-16 12:04:52.736</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33488</identifier><datestamp>2018-07-26T22:10:00Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Crook, Dorothy</field>
+<field name="value">Davis, Francesca</field>
+<field name="value">Jeffries, Joshua</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T15:23:54Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T15:23:54Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-05-21</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33488</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20070521_Dorothy_Crook</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Dorothy Crook, who was at the time of the interview the Director of AFSCME Local 1733, the Memphis chapter of the nationally known labor union. She began working with the Memphis chapter in 1969, the year after Dr. King was assassinated while aiding in the Memphis Sanitation Workers Strike. To this day, Ms. Crook continues for just and equitable treatment of working class citizens in Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/281842908</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Civil rights</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Sanitation Workers Strike, Memphis, Tenn., 1968</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Race relations</field>
+<field name="value">Jackson State University</field>
+<field name="value">Meredith, James</field>
+<field name="value">Sanitation Workers Strike, Memphis, Tenn., 1968</field>
+<field name="value">AFSCME</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Dorothy Crook, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070521_Dorothy_Crook.pdf</field>
+<field name="originalName">20070521_Dorothy_Crook.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">212272</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33488/1/20070521_Dorothy_Crook.pdf</field>
+<field name="checksum">2a55fc4bd608b145ad97f8a5afc7e89b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">Dorothy Crook.JPG</field>
+<field name="originalName">Dorothy Crook.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">59027</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33488/10/Dorothy%20Crook.JPG</field>
+<field name="checksum">5de92381242f5d4bfed102b39461ebd2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">10</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070521_Dorothy_Crook.pdf.txt</field>
+<field name="originalName">20070521_Dorothy_Crook.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">55413</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33488/3/20070521_Dorothy_Crook.pdf.txt</field>
+<field name="checksum">1d63727c700375b0a0e40e4667bd6197</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070521_Dorothy_Crook.pdf.jpg</field>
+<field name="originalName">20070521_Dorothy_Crook.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12587</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33488/4/20070521_Dorothy_Crook.pdf.jpg</field>
+<field name="checksum">31602e78833dbb0a09a4b5e870989ab5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20070521_Dorothy_Crook.JPG.jpg</field>
+<field name="originalName">20070521_Dorothy_Crook.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11129</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33488/5/20070521_Dorothy_Crook.JPG.jpg</field>
+<field name="checksum">58c3b4759e4d0da6bea3ce168573f4da</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+<element name="bitstream">
+<field name="name">Dorothy_Crook.JPG.jpg</field>
+<field name="originalName">Dorothy_Crook.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12529</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33488/8/Dorothy_Crook.JPG.jpg</field>
+<field name="checksum">9e2e46e45e8c2b88fd4b211a53294d7d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+<element name="bitstream">
+<field name="name">Dorothy Crook.JPG.jpg</field>
+<field name="originalName">Dorothy Crook.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13054</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33488/11/Dorothy%20Crook.JPG.jpg</field>
+<field name="checksum">fc196663ba4e29337433b140acd02e78</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">11</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070521_Dorothy_Crook.JPG.preview.jpg</field>
+<field name="originalName">20070521_Dorothy_Crook.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">24145</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33488/6/20070521_Dorothy_Crook.JPG.preview.jpg</field>
+<field name="checksum">83db45b1bc0591a42148b605dc5af3d2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">Dorothy_Crook.JPG.preview.jpg</field>
+<field name="originalName">Dorothy_Crook.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">43095</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33488/9/Dorothy_Crook.JPG.preview.jpg</field>
+<field name="checksum">54e29674d1707406df2587ab08bdc281</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">9</field>
+</element>
+<element name="bitstream">
+<field name="name">Dorothy Crook.JPG.preview.jpg</field>
+<field name="originalName">Dorothy Crook.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">44396</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33488/12/Dorothy%20Crook.JPG.preview.jpg</field>
+<field name="checksum">43abef7bfdb7e505fbbdee532542e0a2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">12</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33488</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33488</field>
+<field name="lastModifyDate">2018-07-26 17:10:00.471</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33466</identifier><datestamp>2018-07-18T17:49:50Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Holliman, Debra</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-16T16:46:32Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-16T16:46:32Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2015-06-29</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33466</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20150629_Debra_Holliman</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Debra Holliman on June 29th, 2015.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280585479</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Lake County (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Debra Holliman, 2015</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150629_Debra_Holliman.pdf</field>
+<field name="originalName">20150629_Debra_Holliman.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">473115</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33466/1/20150629_Debra_Holliman.pdf</field>
+<field name="checksum">a897f44515c5b01776a21591915dc8f0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20150629_Debra_Holliman.PNG</field>
+<field name="originalName">20150629_Debra_Holliman.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1071564</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33466/4/20150629_Debra_Holliman.PNG</field>
+<field name="checksum">0b49ddf781de7cfce64afc6d49651e03</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150629_Debra_Holliman.pdf.txt</field>
+<field name="originalName">20150629_Debra_Holliman.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">12625</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33466/2/20150629_Debra_Holliman.pdf.txt</field>
+<field name="checksum">d5b7b4e97e65e54ee3527afc61246013</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150629_Debra_Holliman.pdf.jpg</field>
+<field name="originalName">20150629_Debra_Holliman.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12317</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33466/3/20150629_Debra_Holliman.pdf.jpg</field>
+<field name="checksum">a6ecd9692e704eeff4608272a0ae462e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20150629_Debra_Holliman.PNG.jpg</field>
+<field name="originalName">20150629_Debra_Holliman.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6457</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33466/5/20150629_Debra_Holliman.PNG.jpg</field>
+<field name="checksum">eb582a6d7d7dc42780e8206f8d537618</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150629_Debra_Holliman.PNG.preview.jpg</field>
+<field name="originalName">20150629_Debra_Holliman.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">24253</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33466/6/20150629_Debra_Holliman.PNG.preview.jpg</field>
+<field name="checksum">321756b8570c39070e7efab07309c317</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33466</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33466</field>
+<field name="lastModifyDate">2018-07-18 12:49:50.177</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33497</identifier><datestamp>2018-07-10T20:56:15Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Willis, Marc</field>
+<field name="value">Jeffries, Joshua</field>
+<field name="value">Borst-Censullo, Stefan</field>
+<field name="value">Willis, Marc</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T15:23:57Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T15:23:57Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-07-25</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33497</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20070725_Marc_Willis</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Marc Willis, who is currently CEO of Soulsville U.S.A. in Memphis, Tennessee. The youngest child of prominent Memphis Civil Rights Attorney and politician A.W. Willis, Marc Willis recalls growing up amidst his father's then bustling political career in the 60's and early 70's. Furthermore, Mr. Willis explains how growing up amidst the Civil Rights Movement influenced his current career choice.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278557472</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Soulsville U.S.A. (Memphis, Tenn.)</field>
+<field name="value">Stax Records</field>
+<field name="value">Willis, A. W., 1925-1988</field>
+<field name="value">Music</field>
+<field name="value">Politics</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Race relations</field>
+<field name="value">Brown, James, 1933-2006</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Marc Willis, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070725_Marc_Willis.JPG</field>
+<field name="originalName">20070725_Marc_Willis.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">33124</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33497/1/20070725_Marc_Willis.JPG</field>
+<field name="checksum">d0f10dc5bf8434d5b576c912a264b28b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20070725_Marc_Willis.pdf</field>
+<field name="originalName">20070725_Marc_Willis.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">308712</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33497/2/20070725_Marc_Willis.pdf</field>
+<field name="checksum">8404dbd94c829e572169ba9dbc23d3c8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070725_Marc_Willis.JPG.jpg</field>
+<field name="originalName">20070725_Marc_Willis.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8611</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33497/3/20070725_Marc_Willis.JPG.jpg</field>
+<field name="checksum">e95de0ac41ec661aeb3c054de31bfde3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20070725_Marc_Willis.pdf.jpg</field>
+<field name="originalName">20070725_Marc_Willis.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13157</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33497/6/20070725_Marc_Willis.pdf.jpg</field>
+<field name="checksum">b91e65bece0207f59763e4191bed1f71</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070725_Marc_Willis.JPG.preview.jpg</field>
+<field name="originalName">20070725_Marc_Willis.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">23679</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33497/4/20070725_Marc_Willis.JPG.preview.jpg</field>
+<field name="checksum">d9133b513b38c4cac4edec867ba48de7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070725_Marc_Willis.pdf.txt</field>
+<field name="originalName">20070725_Marc_Willis.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">53467</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33497/5/20070725_Marc_Willis.pdf.txt</field>
+<field name="checksum">3c16e9191753dcb80625136902173a04</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33497</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33497</field>
+<field name="lastModifyDate">2018-07-10 15:56:15.711</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33651</identifier><datestamp>2018-07-31T18:19:35Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Donelson, Lewis R., III</field>
+<field name="value">Davis, Francesca</field>
+<field name="value">Smith, Tiffany</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T20:59:20Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T20:59:20Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2008-05-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33651</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20080530_Lewis_Donelson</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview Lewis Donelson, a native Memphian and Rhdoes Alum, taks about the role his parents had in his life and his time in college and law school. He also discusses race relations in Memphis in the '50's.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="none">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/281841478</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Education</field>
+<field name="value">Rhodes College</field>
+<field name="value">Law</field>
+<field name="value">Race relations</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Lewis Donelson, 2008</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080530_Lewis_Donelson.JPG</field>
+<field name="originalName">20080530_Lewis_Donelson.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">60919</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33651/1/20080530_Lewis_Donelson.JPG</field>
+<field name="checksum">7b13f87b655073277e751ef40069269d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20080530_Lewis_Donelson.pdf</field>
+<field name="originalName">20080530_Lewis_Donelson.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">266228</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33651/2/20080530_Lewis_Donelson.pdf</field>
+<field name="checksum">12c9a6cf156ac0facdb400e4c781d15d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080530_Lewis_Donelson.JPG.jpg</field>
+<field name="originalName">20080530_Lewis_Donelson.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9411</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33651/3/20080530_Lewis_Donelson.JPG.jpg</field>
+<field name="checksum">830bb3822227d941e26a5a9fcbcb0c88</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20080530_Lewis_Donelson.pdf.jpg</field>
+<field name="originalName">20080530_Lewis_Donelson.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11827</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33651/6/20080530_Lewis_Donelson.pdf.jpg</field>
+<field name="checksum">0da574144c7279bbca5883e90c8e1540</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080530_Lewis_Donelson.JPG.preview.jpg</field>
+<field name="originalName">20080530_Lewis_Donelson.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">35029</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33651/4/20080530_Lewis_Donelson.JPG.preview.jpg</field>
+<field name="checksum">0b5634493de7c5274da7e87fd19af511</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080530_Lewis_Donelson.pdf.txt</field>
+<field name="originalName">20080530_Lewis_Donelson.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">79822</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33651/5/20080530_Lewis_Donelson.pdf.txt</field>
+<field name="checksum">6feca875adb0b1a08809b8c877f72013</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33651</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33651</field>
+<field name="lastModifyDate">2018-07-31 13:19:35.392</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31294</identifier><datestamp>2018-11-11T21:38:14Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Scott, Harold</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-01-17T22:05:14Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-01-17T22:05:14Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2004-08-27</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31294</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20040827_Harold_Scott</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Collection: Stax Oral Histories Interviewee: Harold Scott Interviewer: Unknown</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279725762</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Music</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Stax Records</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Harold Scott, 2004</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040827_Harold_Scott.pdf.txt</field>
+<field name="originalName">20040827_Harold_Scott.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">33871</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31294/3/20040827_Harold_Scott.pdf.txt</field>
+<field name="checksum">907600a0db667e4c97bbe49a29489e1d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040827_Harold_Scott.pdf.jpg</field>
+<field name="originalName">20040827_Harold_Scott.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9726</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31294/4/20040827_Harold_Scott.pdf.jpg</field>
+<field name="checksum">d5cd264bade867c5936cc6a2be8763d1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20040827_Harold_Scott.jpg.jpg</field>
+<field name="originalName">20040827_Harold_Scott.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12413</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31294/5/20040827_Harold_Scott.jpg.jpg</field>
+<field name="checksum">6994573bf72e806df9a2a87de5afafda</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040827_Harold_Scott.jpg</field>
+<field name="originalName">20040827_Harold_Scott.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">89965</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31294/2/20040827_Harold_Scott.jpg</field>
+<field name="checksum">9b7a42d5341d8df424ad60841ee18666</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20040827_Harold_Scott.pdf</field>
+<field name="originalName">20040827_Harold_Scott.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">131267</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31294/7/20040827_Harold_Scott.pdf</field>
+<field name="checksum">828011ecc2f3b541d8c0e850b8abe890</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20040827_Harold_Scott.jpg.preview.jpg</field>
+<field name="originalName">20040827_Harold_Scott.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">45565</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31294/6/20040827_Harold_Scott.jpg.preview.jpg</field>
+<field name="checksum">e59031fa65ca88dbf0632b55800f42ba</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31294</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31294</field>
+<field name="lastModifyDate">2018-11-11 15:38:14.317</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33611</identifier><datestamp>2018-08-01T20:18:29Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Foster, Marlon</field>
+<field name="value">Montgomery, Sumita</field>
+<field name="value">McCain, Tretarius</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:19Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:19Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-07-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33611</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130717_Marlon_Foster</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Marlon Foster. Foster is the pastor of Christ Quest Community Church and the founder of Knowledge Quest.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279706371</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+<field name="value">Nonprofit organizations</field>
+<field name="value">Knowledge Quest (Memphis, Tenn.)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Marlon Foster, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130717_Marlon_Foster.JPG</field>
+<field name="originalName">20130717_Marlon_Foster.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">41101</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33611/1/20130717_Marlon_Foster.JPG</field>
+<field name="checksum">d11af2dcdfecbc5994fa49cee5965dbe</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130717_Marlon_Foster.pdf</field>
+<field name="originalName">20130717_Marlon_Foster.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">174298</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33611/2/20130717_Marlon_Foster.pdf</field>
+<field name="checksum">7cff2b78f5e0595a3d9ec5a633c40107</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130717_Marlon_Foster.JPG.jpg</field>
+<field name="originalName">20130717_Marlon_Foster.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">5210</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33611/3/20130717_Marlon_Foster.JPG.jpg</field>
+<field name="checksum">9b74f606109e57f4d01bc50606abbb40</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130717_Marlon_Foster.pdf.jpg</field>
+<field name="originalName">20130717_Marlon_Foster.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11809</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33611/6/20130717_Marlon_Foster.pdf.jpg</field>
+<field name="checksum">c212279301e4257e841da21fa998bdfb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130717_Marlon_Foster.JPG.preview.jpg</field>
+<field name="originalName">20130717_Marlon_Foster.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">18958</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33611/4/20130717_Marlon_Foster.JPG.preview.jpg</field>
+<field name="checksum">bd2b801537d6fdc0684eddc3adc666a0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130717_Marlon_Foster.pdf.txt</field>
+<field name="originalName">20130717_Marlon_Foster.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">26796</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33611/5/20130717_Marlon_Foster.pdf.txt</field>
+<field name="checksum">82bee81153d0553c198844919d584b16</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33611</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33611</field>
+<field name="lastModifyDate">2018-08-01 15:18:29.115</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33662</identifier><datestamp>2018-07-20T17:16:27Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Hooks, Frances</field>
+<field name="value">Hooks, Benjamin L. (Benjamin Lawson), 1925-2010</field>
+<field name="value">Smith, Tiffani</field>
+<field name="value">James, Holly</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T20:59:22Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T20:59:22Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2008-07-09</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33662</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20080709_Frances_and_Benjamin_Hooks</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Frances and Benjamin Hooks.Frances Hooks  is a retired school teacher and Benjamin Hooks was a minister and attorney. They discuss growing up during the Great Depression, with a specific focus on education. Benjamin Hooks also describes his role in the Civil rights movement as a joint venture with his wife and describes the circumstances leading to the Sanitation Strike.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="none">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278570836</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Education</field>
+<field name="value">Religion</field>
+<field name="value">Law</field>
+<field name="value">Great Depression, 1929</field>
+<field name="value">Sanitation Workers Strike, Memphis, Tenn., 1968</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Race relations</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Frances and Benjamin Hooks, 2008</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080709_Frances_and_Benjamin_Hooks.JPG</field>
+<field name="originalName">20080709_Frances_and_Benjamin_Hooks.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">79184</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33662/1/20080709_Frances_and_Benjamin_Hooks.JPG</field>
+<field name="checksum">cdada709fb045f8c3edc702f7c1cf3c1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20080709_Frances_and_Benjamin_Hooks.pdf</field>
+<field name="originalName">20080709_Frances_and_Benjamin_Hooks.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">271678</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33662/2/20080709_Frances_and_Benjamin_Hooks.pdf</field>
+<field name="checksum">3d5822a8bc072a366d7f8fba890e358c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080709_Frances_and_Benjamin_Hooks.JPG.jpg</field>
+<field name="originalName">20080709_Frances_and_Benjamin_Hooks.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13710</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33662/3/20080709_Frances_and_Benjamin_Hooks.JPG.jpg</field>
+<field name="checksum">c09b4f41c9db6498a4b1a211e3184d87</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20080709_Frances_and_Benjamin_Hooks.pdf.jpg</field>
+<field name="originalName">20080709_Frances_and_Benjamin_Hooks.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11865</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33662/6/20080709_Frances_and_Benjamin_Hooks.pdf.jpg</field>
+<field name="checksum">b773399334b980ecabd42cd3ac1be97c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080709_Frances_and_Benjamin_Hooks.JPG.preview.jpg</field>
+<field name="originalName">20080709_Frances_and_Benjamin_Hooks.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">47953</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33662/4/20080709_Frances_and_Benjamin_Hooks.JPG.preview.jpg</field>
+<field name="checksum">547627c5bbe8e189f16404dc2343ea9a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080709_Frances_and_Benjamin_Hooks.pdf.txt</field>
+<field name="originalName">20080709_Frances_and_Benjamin_Hooks.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">66086</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33662/5/20080709_Frances_and_Benjamin_Hooks.pdf.txt</field>
+<field name="checksum">7e5ef105c6a78acc66eacc24a3cef1f0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33662</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33662</field>
+<field name="lastModifyDate">2018-07-20 12:16:27.257</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33478</identifier><datestamp>2018-07-16T17:04:53Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Jones, Evan</field>
+<field name="value">Watson, Shane</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-16T16:46:35Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-16T16:46:35Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-06-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33478</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140619_Evan_Jones</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Evan Jones discusses his experiences growing up and living in Lake County, TN.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279914487</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Lake County (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Evan Jones, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140619_Evan_Jones.JPG</field>
+<field name="originalName">20140619_Evan_Jones.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">61410</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33478/1/20140619_Evan_Jones.JPG</field>
+<field name="checksum">d84fbed29f4a4d989731d8bf0892b6b5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140619_Evan_Jones.pdf</field>
+<field name="originalName">20140619_Evan_Jones.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">163032</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33478/2/20140619_Evan_Jones.pdf</field>
+<field name="checksum">0adbb023fa90f0dd8f0d0e990a234885</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140619_Evan_Jones.JPG.jpg</field>
+<field name="originalName">20140619_Evan_Jones.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8060</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33478/3/20140619_Evan_Jones.JPG.jpg</field>
+<field name="checksum">48ff42b606f0f01dfb8d354c24bb608a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140619_Evan_Jones.pdf.jpg</field>
+<field name="originalName">20140619_Evan_Jones.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12337</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33478/6/20140619_Evan_Jones.pdf.jpg</field>
+<field name="checksum">c2f27f4703783b9e5798d0d19e0ab295</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140619_Evan_Jones.JPG.preview.jpg</field>
+<field name="originalName">20140619_Evan_Jones.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">30163</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33478/4/20140619_Evan_Jones.JPG.preview.jpg</field>
+<field name="checksum">1b80ddb22c201c48a8ed0656b0f2c994</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140619_Evan_Jones.pdf.txt</field>
+<field name="originalName">20140619_Evan_Jones.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">21315</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33478/5/20140619_Evan_Jones.pdf.txt</field>
+<field name="checksum">8f2c04618c7bc4baa1f857b1fce4e618</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33478</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33478</field>
+<field name="lastModifyDate">2018-07-16 12:04:53.195</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33665</identifier><datestamp>2018-07-26T17:09:14Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Hunt, George</field>
+<field name="value">Turner, Lauren</field>
+<field name="value">James, Holly</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T20:59:23Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T20:59:23Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2008-07-15</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33665</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20080715_George_Hunt</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with George Hunt, a Memphis (Tenn.) artist. Hunt was born in Lake Charles, Louisiana and grew up in Hot Springs, Arkansas before coming to Memphis. Mr. Hunt, a former Memphis City School Art teacher and coach at George Washington Carver High School describes his experiences in Memphis as a teacher and artist. He also shares his memories about the climate in Memphis during the Civil Rights Movement and how his art was influenced by the events occurring around him.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="none">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/281840514</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Tennessee</field>
+<field name="value">Civil rights</field>
+<field name="value">Segregation</field>
+<field name="value">Education</field>
+<field name="value">Race relations</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">George Hunt, 2008</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080715_George_Hunt.JPG</field>
+<field name="originalName">20080715_George_Hunt.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">60281</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33665/1/20080715_George_Hunt.JPG</field>
+<field name="checksum">6cd86a721c40c17f1e78b1de3be3f854</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20080715_George_Hunt.pdf</field>
+<field name="originalName">20080715_George_Hunt.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">281423</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33665/2/20080715_George_Hunt.pdf</field>
+<field name="checksum">681ca2ea9bf8cebd27374c5dfc71fc02</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080715_George_Hunt.JPG.jpg</field>
+<field name="originalName">20080715_George_Hunt.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11224</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33665/3/20080715_George_Hunt.JPG.jpg</field>
+<field name="checksum">9ac8b7bd004a7a6a25bb3f4420458f1c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20080715_George_Hunt.pdf.jpg</field>
+<field name="originalName">20080715_George_Hunt.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12111</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33665/6/20080715_George_Hunt.pdf.jpg</field>
+<field name="checksum">aa601e02c061032c7e0acdab57f447b8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080715_George_Hunt.JPG.preview.jpg</field>
+<field name="originalName">20080715_George_Hunt.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">39574</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33665/4/20080715_George_Hunt.JPG.preview.jpg</field>
+<field name="checksum">23396cfb57db68077f1b3ac99dada2c1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080715_George_Hunt.pdf.txt</field>
+<field name="originalName">20080715_George_Hunt.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">74252</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33665/5/20080715_George_Hunt.pdf.txt</field>
+<field name="checksum">3e7ae3b87a1822303ce446b4cfc52683</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33665</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33665</field>
+<field name="lastModifyDate">2018-07-26 12:09:14.47</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33367</identifier><datestamp>2018-07-17T17:06:08Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Glisson, Phil</field>
+<field name="value">Looney, Brittany</field>
+<field name="value">Hibbert, Caroline</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:34Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:34Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-07-03</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33367</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130703_Phil_Glisson</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Interview of community member Phil Glisson from The Heights History Camp, 2013. Interviewed by Treadwell Middle students, sponsored by The Corners at Highland Heights Shalom Zone, Rhodes College, and The Center for Transforming Communities</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280399522</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Phil Glisson, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130703_Phil_Glisson.PNG</field>
+<field name="originalName">20130703_Phil_Glisson.PNG</field>
+<field name="format">image/png</field>
+<field name="size">335288</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33367/1/20130703_Phil_Glisson.PNG</field>
+<field name="checksum">a137924d7892e13d0d93289a4ce1a788</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130703_Phil_Glisson.pdf</field>
+<field name="originalName">20130703_Phil_Glisson.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">145889</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33367/2/20130703_Phil_Glisson.pdf</field>
+<field name="checksum">acbcd1f450d137e64c0d47eec654ed6b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.PNG.jpg</field>
+<field name="originalName">Capture.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6883</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33367/3/Capture.PNG.jpg</field>
+<field name="checksum">46792c2fc0fdc12cf89ea5da322b222c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130703_Phil_Glisson.pdf.jpg</field>
+<field name="originalName">20130703_Phil_Glisson.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10570</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33367/6/20130703_Phil_Glisson.pdf.jpg</field>
+<field name="checksum">05f71c353c7e502f3e5968e195ae3c5b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20130703_Phil_Glisson.PNG.jpg</field>
+<field name="originalName">20130703_Phil_Glisson.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6883</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33367/7/20130703_Phil_Glisson.PNG.jpg</field>
+<field name="checksum">46792c2fc0fdc12cf89ea5da322b222c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.PNG.preview.jpg</field>
+<field name="originalName">Capture.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">18783</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33367/4/Capture.PNG.preview.jpg</field>
+<field name="checksum">3759bc602fa506952e80d7ec3dcc64bf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20130703_Phil_Glisson.PNG.preview.jpg</field>
+<field name="originalName">20130703_Phil_Glisson.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">18783</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33367/8/20130703_Phil_Glisson.PNG.preview.jpg</field>
+<field name="checksum">3759bc602fa506952e80d7ec3dcc64bf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130703_Phil_Glisson.pdf.txt</field>
+<field name="originalName">20130703_Phil_Glisson.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">17246</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33367/5/20130703_Phil_Glisson.pdf.txt</field>
+<field name="checksum">3a7af7eb6f75676845fc9191cf75cafb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33367</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33367</field>
+<field name="lastModifyDate">2018-07-17 12:06:08.505</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33519</identifier><datestamp>2018-07-12T18:20:40Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Stanford, Suzanne</field>
+<field name="value">Mrkva, Andy</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T16:29:18Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T16:29:18Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2009-07-07</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33519</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20090707_Susie_Sanford</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, Susie Stanford discusses her life growing up in North Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278576335</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Hyde Park (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">North Memphis</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Suzanne Stanford, 2009</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090707_Susie_Sanford.PNG</field>
+<field name="originalName">20090707_Susie_Sanford.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1636093</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33519/1/20090707_Susie_Sanford.PNG</field>
+<field name="checksum">8aebd3cf8191056442beb02257fc6cc0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20090707_Susie_Sanford.pdf</field>
+<field name="originalName">20090707_Susie_Sanford.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">331762</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33519/2/20090707_Susie_Sanford.pdf</field>
+<field name="checksum">a6cd294c6da3cfa14772f40d0cd8712c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090707_Susie_Sanford.PNG.jpg</field>
+<field name="originalName">20090707_Susie_Sanford.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8096</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33519/3/20090707_Susie_Sanford.PNG.jpg</field>
+<field name="checksum">8c8562badaf21613f98bddcdf78531c4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20090707_Susie_Sanford.pdf.jpg</field>
+<field name="originalName">20090707_Susie_Sanford.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7676</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33519/6/20090707_Susie_Sanford.pdf.jpg</field>
+<field name="checksum">48cdfc207a5991087250981adfc7c870</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090707_Susie_Sanford.PNG.preview.jpg</field>
+<field name="originalName">20090707_Susie_Sanford.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">31619</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33519/4/20090707_Susie_Sanford.PNG.preview.jpg</field>
+<field name="checksum">c19bb029249f7aff2f6c80ed8fe368ca</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090707_Susie_Sanford.pdf.txt</field>
+<field name="originalName">20090707_Susie_Sanford.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">27386</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33519/5/20090707_Susie_Sanford.pdf.txt</field>
+<field name="checksum">653a3b2e006b233a46286d5364a041fb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33519</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33519</field>
+<field name="lastModifyDate">2018-07-12 13:20:40.319</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33517</identifier><datestamp>2018-07-16T20:53:06Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Cash, JoAnne</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T16:29:18Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T16:29:18Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2009-07-01</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33517</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20090701_JoAnne_Cash</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Joanne Cash, Johnny Cash's younger sister. In this interview, she discusses the life of Johnny Cash, on the site of Mr. Cash's first Memphis performance, now the Lifelink Church of Memphis at 1015 Cooper.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280261842</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Hyde Park (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Cash, Johnny</field>
+<field name="value">Music</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">JoAnne Cash, 2009</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090701_JoAnne_Cash.PNG</field>
+<field name="originalName">20090701_JoAnne_Cash.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1940453</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33517/1/20090701_JoAnne_Cash.PNG</field>
+<field name="checksum">cef8517caf4503a7932acd2ebc874948</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20090701_JoAnne_Cash.pdf</field>
+<field name="originalName">20090701_JoAnne_Cash.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">399334</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33517/2/20090701_JoAnne_Cash.pdf</field>
+<field name="checksum">e9e029d2aaaec2c6de4048bcccabdeaa</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090701_JoAnne_Cash.PNG.jpg</field>
+<field name="originalName">20090701_JoAnne_Cash.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9145</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33517/3/20090701_JoAnne_Cash.PNG.jpg</field>
+<field name="checksum">09e5807076e1365b3eb1f6880fec8579</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20090701_JoAnne_Cash.pdf.jpg</field>
+<field name="originalName">20090701_JoAnne_Cash.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9540</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33517/6/20090701_JoAnne_Cash.pdf.jpg</field>
+<field name="checksum">cae5ee47e90a2adb50590b50f1f88b45</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090701_JoAnne_Cash.PNG.preview.jpg</field>
+<field name="originalName">20090701_JoAnne_Cash.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">37875</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33517/4/20090701_JoAnne_Cash.PNG.preview.jpg</field>
+<field name="checksum">487c8c8f0cb4bcf1f728737f2910b3c4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20090701_JoAnne_Cash.pdf.txt</field>
+<field name="originalName">20090701_JoAnne_Cash.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">56590</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33517/5/20090701_JoAnne_Cash.pdf.txt</field>
+<field name="checksum">4e6757ce10e1b42c45f3854937106397</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33517</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33517</field>
+<field name="lastModifyDate">2018-07-16 15:53:06.323</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33370</identifier><datestamp>2018-08-02T20:05:56Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Morton, Fred</field>
+<field name="value">Looney, Brittany</field>
+<field name="value">Lemus, Diana</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:35Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:35Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-07-10</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33370</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130710_Fred_Morton</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Interview of community member Fred Morton from The Heights History Camp, 2013. Interviewed by Treadwell Middle students, sponsored by The Corners at Highland Heights Shalom Zone, Rhodes College, and The Center for Transforming Communities</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/282887725</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Fred Morton, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130710_Fred_Morton.PNG</field>
+<field name="originalName">20130710_Fred_Morton.PNG</field>
+<field name="format">image/png</field>
+<field name="size">569329</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33370/1/20130710_Fred_Morton.PNG</field>
+<field name="checksum">92ba9720f3604ed7e27dfa0fbb08d3ad</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130710_Fred_Morton.pdf</field>
+<field name="originalName">20130710_Fred_Morton.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">157294</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33370/2/20130710_Fred_Morton.pdf</field>
+<field name="checksum">16f5b4302b06bb8f487dca8b5b99532d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">morton 1014.PNG.jpg</field>
+<field name="originalName">morton 1014.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7602</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33370/3/morton%201014.PNG.jpg</field>
+<field name="checksum">1c6dbe2b84a960f23b095806ed664537</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130710_Fred_Morton.pdf.jpg</field>
+<field name="originalName">20130710_Fred_Morton.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12558</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33370/6/20130710_Fred_Morton.pdf.jpg</field>
+<field name="checksum">f09536bbe5be99c0b1c25128237d913b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20130710_Fred_Morton.PNG.jpg</field>
+<field name="originalName">20130710_Fred_Morton.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7602</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33370/7/20130710_Fred_Morton.PNG.jpg</field>
+<field name="checksum">1c6dbe2b84a960f23b095806ed664537</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">morton 1014.PNG.preview.jpg</field>
+<field name="originalName">morton 1014.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">29846</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33370/4/morton%201014.PNG.preview.jpg</field>
+<field name="checksum">9a0d778db7ca6b7309ac2da465e5dfe1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20130710_Fred_Morton.PNG.preview.jpg</field>
+<field name="originalName">20130710_Fred_Morton.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">29846</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33370/8/20130710_Fred_Morton.PNG.preview.jpg</field>
+<field name="checksum">9a0d778db7ca6b7309ac2da465e5dfe1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130710_Fred_Morton.pdf.txt</field>
+<field name="originalName">20130710_Fred_Morton.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">27217</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33370/5/20130710_Fred_Morton.pdf.txt</field>
+<field name="checksum">9728f52a3de6aaa4f73162fc4ef6c767</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33370</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33370</field>
+<field name="lastModifyDate">2018-08-02 15:05:56.031</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33541</identifier><datestamp>2018-08-01T20:19:51Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Mabern, Harold</field>
+<field name="value">Whitehorn, Molly</field>
+<field name="value">Bass, John B. III</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T14:48:50Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T14:48:50Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-11-22</field>
+</element>
+</element>
+<element name="graduation">
+<element name="none">
+<field name="value">2015</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33541</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20131122_Harold_Mabern</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, Harold Mabern discusses his music career and his experiences in Memphis. Interview conducted by Molly Whitehorn ('15) and Dr. John Bass on November 22, 2013.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278585265</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Music</field>
+<field name="value">Mike Curb Institute for Music</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Harold Mabern, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20131122_Harold_Mabern.JPG.jpg</field>
+<field name="originalName">20131122_Harold_Mabern.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10097</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33541/3/20131122_Harold_Mabern.JPG.jpg</field>
+<field name="checksum">f6c5df233b9a27ef4bd7fa913edabb1e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20131122_Harold_Mabern.pdf.jpg</field>
+<field name="originalName">20131122_Harold_Mabern.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12423</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33541/6/20131122_Harold_Mabern.pdf.jpg</field>
+<field name="checksum">16b7c709d54ac07178cb799f53bb3574</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20131122_Harold_Mabern.JPG.preview.jpg</field>
+<field name="originalName">20131122_Harold_Mabern.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">23026</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33541/4/20131122_Harold_Mabern.JPG.preview.jpg</field>
+<field name="checksum">94d1da3b59d2648497f39c8ed9890b4a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20131122_Harold_Mabern.pdf.txt</field>
+<field name="originalName">20131122_Harold_Mabern.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">84827</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33541/5/20131122_Harold_Mabern.pdf.txt</field>
+<field name="checksum">12bbc62f50a03370614fdb450a31b5e2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20131122_Harold_Mabern.JPG</field>
+<field name="originalName">20131122_Harold_Mabern.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">31772</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33541/1/20131122_Harold_Mabern.JPG</field>
+<field name="checksum">169689b188ca288600cc55732a22ef03</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20131122_Harold_Mabern.pdf</field>
+<field name="originalName">20131122_Harold_Mabern.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">375135</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33541/2/20131122_Harold_Mabern.pdf</field>
+<field name="checksum">30ab3ee678c79113b7b507423a2d028d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33541</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33541</field>
+<field name="lastModifyDate">2018-08-01 15:19:51.675</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33487</identifier><datestamp>2018-07-20T17:15:07Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Ivory, Luther D., 1953-</field>
+<field name="value">Davis, Francesca</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T15:23:54Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T15:23:54Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-05-16</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33487</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20070516_Luther_Ivory</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Luther Ivory, associate professor at Rhodes College, received his B.S. and M.S. from the University of Tennessee and his Doctor of Ministry from Union Theological Seminary and his Ph.D. from the Candler School of Theology at Emory University. Prof. Ivory served in the Navy for five years as lieutenant and was ordained as a minister of the Word and Sacraments by the Presbytery of Memphis [Presbyterian Church (USA)] to pursue the vocation of teaching. In addition to teaching at Rhodes, Prof. Ivory is pastor at St. Andrews Presbyterian Church USA in Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278552327</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Religion</field>
+<field name="value">Civil rights</field>
+<field name="value">Rhodes College (Memphis, Tenn.)</field>
+<field name="value">Race relations</field>
+<field name="value">Sanitation Workers Strike, Memphis, Tenn., 1968</field>
+<field name="value">Smith, Coby</field>
+<field name="value">King, Martin Luther, Jr., 1929-1968</field>
+<field name="value">AFSCME</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Luther Ivory, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070516_Luther_Ivory.JPG</field>
+<field name="originalName">20070516_Luther_Ivory.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">54018</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33487/1/20070516_Luther_Ivory.JPG</field>
+<field name="checksum">14d30b965efe9443ced1a17afebbe593</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20070516_Luther_Ivory.pdf</field>
+<field name="originalName">20070516_Luther_Ivory.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">422728</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33487/2/20070516_Luther_Ivory.pdf</field>
+<field name="checksum">ffc706bb32b98ad3cd23e515743c4e5f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070516_Luther_Ivory.JPG.jpg</field>
+<field name="originalName">20070516_Luther_Ivory.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12915</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33487/3/20070516_Luther_Ivory.JPG.jpg</field>
+<field name="checksum">bdb55ee0a57e5ba954b81a70866b26c9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20070516_Luther_Ivory.pdf.jpg</field>
+<field name="originalName">20070516_Luther_Ivory.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10113</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33487/6/20070516_Luther_Ivory.pdf.jpg</field>
+<field name="checksum">4a31539ba4155c0142afbcc4a61b7f74</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070516_Luther_Ivory.JPG.preview.jpg</field>
+<field name="originalName">20070516_Luther_Ivory.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">37492</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33487/4/20070516_Luther_Ivory.JPG.preview.jpg</field>
+<field name="checksum">c28457ec9865ebcd5468e9e96fc71ecf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070516_Luther_Ivory.pdf.txt</field>
+<field name="originalName">20070516_Luther_Ivory.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">54845</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33487/5/20070516_Luther_Ivory.pdf.txt</field>
+<field name="checksum">6c9988593bd414f8bc64a9a2fab197f4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33487</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33487</field>
+<field name="lastModifyDate">2018-07-20 12:15:07.991</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33395</identifier><datestamp>2018-07-26T21:29:39Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Khandekar, Alim</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-01T15:16:31Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-01T15:16:31Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-07-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33395</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140717_Dr_Alim_ Khandekar</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Collection: Islam in Memphis Oral Histories, Interviewees: Dr. Alim Khandekar, Date: 2014-07-17</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/281699285</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Islam</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Dr. Alim Khandekar, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140717_Dr_Alim_ Khandekar.PNG</field>
+<field name="originalName">20140717_Dr_Alim_ Khandekar.PNG</field>
+<field name="format">image/png</field>
+<field name="size">2653722</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33395/2/20140717_Dr_Alim_%20Khandekar.PNG</field>
+<field name="checksum">88dc6ea2255202170476825ad48b2a1b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20140717_Dr_Alim_ Khandekar.pdf</field>
+<field name="originalName">20140717_Dr_Alim_ Khandekar.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">590933</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33395/5/20140717_Dr_Alim_%20Khandekar.pdf</field>
+<field name="checksum">2c424b58fa57cb067475129dbaa467a1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140717_Dr_Alim_ Khandekar.PNG.jpg</field>
+<field name="originalName">20140717_Dr_Alim_ Khandekar.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11192</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33395/3/20140717_Dr_Alim_%20Khandekar.PNG.jpg</field>
+<field name="checksum">aad13976e12763c432f05efffa15bc2c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140717_Dr_Alim_ Khandekar.pdf.jpg</field>
+<field name="originalName">20140717_Dr_Alim_ Khandekar.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11037</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33395/7/20140717_Dr_Alim_%20Khandekar.pdf.jpg</field>
+<field name="checksum">39823b5a2ee49bc37b8a74bbef5e79e1</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140717_Dr_Alim_ Khandekar.PNG.preview.jpg</field>
+<field name="originalName">20140717_Dr_Alim_ Khandekar.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">49905</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33395/4/20140717_Dr_Alim_%20Khandekar.PNG.preview.jpg</field>
+<field name="checksum">30954a2ffadbc75b98ed8a39acadb37b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140717_Dr_Alim_ Khandekar.pdf.txt</field>
+<field name="originalName">20140717_Dr_Alim_ Khandekar.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">17039</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33395/6/20140717_Dr_Alim_%20Khandekar.pdf.txt</field>
+<field name="checksum">d18ba5b5d72de723f822a721464a09f2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33395</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33395</field>
+<field name="lastModifyDate">2018-07-26 16:29:39.323</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33558</identifier><datestamp>2018-07-12T18:20:40Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Wray, Harmon</field>
+<field name="value">Jacobs, Daniel</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T15:16:05Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T15:16:05Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2006-11-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33558</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20061130_Harmon_Wray</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Mr. Harmon Wray was a Rhodes student who graduated in 1968, and he is currently the Director of the Vanderbilt Program in Faith and Criminal Justice. In this interview he describes his childhood growing up in Memphis and his early memories of race relations. He also talks about the controversy he was involved in at Rhodes over admitting a black student into the ATO fraternity, his memories of the period following Dr. Martin Luther King�s assassination and his decision to become a criminal justice reform activist.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278541892</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Rhodes College</field>
+<field name="value">Law</field>
+<field name="value">Segregation</field>
+<field name="value">Race relations</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Harmon Wray, 2006</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061130_Harmon_Wray.jpg</field>
+<field name="originalName">20061130_Harmon_Wray.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">246335</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33558/1/20061130_Harmon_Wray.jpg</field>
+<field name="checksum">0ccc7cdbcafaee7a24ecc1a910a2e473</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20061130_Harmon_Wray.pdf</field>
+<field name="originalName">20061130_Harmon_Wray.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">230282</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33558/2/20061130_Harmon_Wray.pdf</field>
+<field name="checksum">555733a149232215b58400e41354c3a5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061130_Harmon_Wray.jpg.jpg</field>
+<field name="originalName">20061130_Harmon_Wray.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12583</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33558/3/20061130_Harmon_Wray.jpg.jpg</field>
+<field name="checksum">63cd6c3952699198b62d1375a7389148</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20061130_Harmon_Wray.pdf.jpg</field>
+<field name="originalName">20061130_Harmon_Wray.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">14033</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33558/6/20061130_Harmon_Wray.pdf.jpg</field>
+<field name="checksum">e1c38bbce4b3a471e4b29db08ce50722</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061130_Harmon_Wray.jpg.preview.jpg</field>
+<field name="originalName">20061130_Harmon_Wray.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">59071</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33558/4/20061130_Harmon_Wray.jpg.preview.jpg</field>
+<field name="checksum">c2ed17c72405e49cc89bf7578764a517</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20061130_Harmon_Wray.pdf.txt</field>
+<field name="originalName">20061130_Harmon_Wray.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">52158</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33558/5/20061130_Harmon_Wray.pdf.txt</field>
+<field name="checksum">8e6ade98b2c9e40d637b09303c83d82a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33558</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33558</field>
+<field name="lastModifyDate">2018-07-12 13:20:40.491</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33664</identifier><datestamp>2018-07-16T20:46:08Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Snowden-Jones, Dorothy (Happy)</field>
+<field name="value">Smith, Tiffani</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T20:59:23Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T20:59:23Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2008-07-14</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33664</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20080714_Dorothy_Happy_Jones</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Dorothy "Happy" Jones. In the interview she talks about working with the Memphis Panel of American Women, the Republican Party and the Concerned Women of Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="none">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280259311</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Panel of American Women</field>
+<field name="value">Politics</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Dorothy Jones, 2008</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080714_Dorothy_Happy_Jones.JPG</field>
+<field name="originalName">20080714_Dorothy_Happy_Jones.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">89105</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33664/1/20080714_Dorothy_Happy_Jones.JPG</field>
+<field name="checksum">7301dea1606f7e8a2a5d32c664e7b7b6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20080714_Dorothy_Happy_Jones.pdf</field>
+<field name="originalName">20080714_Dorothy_Happy_Jones.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">219237</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33664/2/20080714_Dorothy_Happy_Jones.pdf</field>
+<field name="checksum">f5cfa5c014ab0b8cb66696e4b6db2e7d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080714_Dorothy_Happy_Jones.JPG.jpg</field>
+<field name="originalName">20080714_Dorothy_Happy_Jones.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10949</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33664/3/20080714_Dorothy_Happy_Jones.JPG.jpg</field>
+<field name="checksum">e9ef432e7167ff2cf3c708ea33f08cfb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20080714_Dorothy_Happy_Jones.pdf.jpg</field>
+<field name="originalName">20080714_Dorothy_Happy_Jones.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12071</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33664/6/20080714_Dorothy_Happy_Jones.pdf.jpg</field>
+<field name="checksum">dc4fc08c8447307f42c3ab245f599866</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080714_Dorothy_Happy_Jones.JPG.preview.jpg</field>
+<field name="originalName">20080714_Dorothy_Happy_Jones.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">41762</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33664/4/20080714_Dorothy_Happy_Jones.JPG.preview.jpg</field>
+<field name="checksum">48131e912e79fd425bf028639b903dac</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080714_Dorothy_Happy_Jones.pdf.txt</field>
+<field name="originalName">20080714_Dorothy_Happy_Jones.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">40520</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33664/5/20080714_Dorothy_Happy_Jones.pdf.txt</field>
+<field name="checksum">ca038d0ae9e851930e48df17083fa7fe</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33664</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33664</field>
+<field name="lastModifyDate">2018-07-16 15:46:08.042</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33539</identifier><datestamp>2018-07-26T21:25:46Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Luchessi, Linda</field>
+<field name="value">Whitehorn, Molly</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T14:48:49Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T14:48:49Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-09-06</field>
+</element>
+</element>
+<element name="graduation">
+<element name="none">
+<field name="value">2015</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33539</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130906_Linda_Luchessi</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Linda Luchessi conducted by Molly Whitehorn ('15) and Dr. John Bass on September 6, 2013.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/281666213</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Music</field>
+<field name="value">Mike Curb Institute for Music</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Linda Luchessi, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130906_Linda_Luchessi.PNG.jpg</field>
+<field name="originalName">20130906_Linda_Luchessi.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8800</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33539/3/20130906_Linda_Luchessi.PNG.jpg</field>
+<field name="checksum">ff38484e0999db706d3622e02658d7d3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130906_Linda_Luchessi.pdf.jpg</field>
+<field name="originalName">20130906_Linda_Luchessi.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10754</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33539/6/20130906_Linda_Luchessi.pdf.jpg</field>
+<field name="checksum">65d854e7eadd4cf6477f88f9c37aef5a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130906_Linda_Luchessi.PNG.preview.jpg</field>
+<field name="originalName">20130906_Linda_Luchessi.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">31775</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33539/4/20130906_Linda_Luchessi.PNG.preview.jpg</field>
+<field name="checksum">d3446a501a5e662af04e5e4039f88c4d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130906_Linda_Luchessi.pdf.txt</field>
+<field name="originalName">20130906_Linda_Luchessi.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">31166</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33539/5/20130906_Linda_Luchessi.pdf.txt</field>
+<field name="checksum">a28db55a4da70e1140bd7503043dcad3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130906_Linda_Luchessi.PNG</field>
+<field name="originalName">20130906_Linda_Luchessi.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1638722</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33539/1/20130906_Linda_Luchessi.PNG</field>
+<field name="checksum">eacf15932b050980d5cacf258513217a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130906_Linda_Luchessi.pdf</field>
+<field name="originalName">20130906_Linda_Luchessi.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">277953</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33539/2/20130906_Linda_Luchessi.pdf</field>
+<field name="checksum">a205c290aeb44dbcbe30066d150717a6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33539</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33539</field>
+<field name="lastModifyDate">2018-07-26 16:25:46.948</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/31288</identifier><datestamp>2018-08-07T17:36:40Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">West, Norman</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-01-17T22:05:13Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-01-17T22:05:13Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2005-05-11</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/31288</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20050511_Norman_West</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Norman West conducted on May 11, 2005. He was a member of "The Soul Children," an American vocal group who recorded soul music for Stax Records in the late 1960's and early 1970's. "The Soul Children" were founded by Isaac Hayes and David Porter.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279731894</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Music</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Stax Records</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Norman West, 2005</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20050511_Norman_West.pdf.txt</field>
+<field name="originalName">20050511_Norman_West.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">39170</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31288/3/20050511_Norman_West.pdf.txt</field>
+<field name="checksum">403e0a049035994d7cb3c10629654df3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20050511_Norman_West.pdf.jpg</field>
+<field name="originalName">20050511_Norman_West.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11589</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31288/4/20050511_Norman_West.pdf.jpg</field>
+<field name="checksum">c8b390b4ee886848842bc529c2fa9ddd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20050511_Norman_West.jpg.jpg</field>
+<field name="originalName">20050511_Norman_West.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8531</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31288/5/20050511_Norman_West.jpg.jpg</field>
+<field name="checksum">24198096659758c531190d6e99fbd274</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20050511_Norman_West.pdf</field>
+<field name="originalName">20050511_Norman_West.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">98473</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31288/1/20050511_Norman_West.pdf</field>
+<field name="checksum">00c76d1e2a7d4979e5e3ae0e76af3642</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20050511_Norman_West.jpg</field>
+<field name="originalName">20050511_Norman_West.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">89101</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31288/2/20050511_Norman_West.jpg</field>
+<field name="checksum">933d0097866ce504fe3073fb053f6031</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20050511_Norman_West.jpg.preview.jpg</field>
+<field name="originalName">20050511_Norman_West.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">30194</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/31288/6/20050511_Norman_West.jpg.preview.jpg</field>
+<field name="checksum">99cd22b46864e56d92ce2facf25bef52</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/31288</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/31288</field>
+<field name="lastModifyDate">2018-08-07 12:36:40.739</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33605</identifier><datestamp>2018-07-17T16:53:26Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Tucker, Hattie</field>
+<field name="value">Crump, Mikia</field>
+<field name="value">Jones, Cameron</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T15:38:18Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T15:38:18Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-06-26</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33605</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130626_Hattie_Tucker</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Hattie Tucker. She talks about growing up on a farm in Mississippi and segregation in Memphis.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280396526</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">South Memphis (Memphis, Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Segregation</field>
+<field name="value">Civil rights</field>
+<field name="value">Mississippi</field>
+<field name="value">Farms</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Hattie Tucker, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_Hattie_Tucker.JPG</field>
+<field name="originalName">20130626_Hattie_Tucker.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">46626</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33605/1/20130626_Hattie_Tucker.JPG</field>
+<field name="checksum">4fdec8d1252189eb03a244f794ad5235</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_Hattie_Tucker.pdf</field>
+<field name="originalName">20130626_Hattie_Tucker.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">162511</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33605/2/20130626_Hattie_Tucker.pdf</field>
+<field name="checksum">de5798a5208f4cb4e044e63c874e6d67</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_Hattie_Tucker.JPG.jpg</field>
+<field name="originalName">20130626_Hattie_Tucker.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6002</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33605/3/20130626_Hattie_Tucker.JPG.jpg</field>
+<field name="checksum">bf0f1cd99a8be8043078bbcf2e668741</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_Hattie_Tucker.pdf.jpg</field>
+<field name="originalName">20130626_Hattie_Tucker.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11799</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33605/6/20130626_Hattie_Tucker.pdf.jpg</field>
+<field name="checksum">2068651ea8d10742041d1e40e1608f0f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_Hattie_Tucker.JPG.preview.jpg</field>
+<field name="originalName">20130626_Hattie_Tucker.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">22956</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33605/4/20130626_Hattie_Tucker.JPG.preview.jpg</field>
+<field name="checksum">ec4c650e4bc10864733836e33b4d80be</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_Hattie_Tucker.pdf.txt</field>
+<field name="originalName">20130626_Hattie_Tucker.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">22615</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33605/5/20130626_Hattie_Tucker.pdf.txt</field>
+<field name="checksum">23fd7dd481ad680e5bbc7ce8b7facbcb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33605</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33605</field>
+<field name="lastModifyDate">2018-07-17 11:53:26.307</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33584</identifier><datestamp>2018-07-12T18:20:40Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Flanagan, Mark</field>
+<field name="value">Shepherd, William</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-23T18:43:17Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-23T18:43:17Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2011-04-02</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33584</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20110402_Mark_Flanagan</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, Mark Flanagan shares his experiences as a musician in Memphis. He speaks about the revitalization of Beale and the construction of the Handy Park venue. Interviewee: Mark Flanagan Interviewer: William Shepherd Date: April 2, 2011</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279477754</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Music</field>
+<field name="value">WC Handy Performing Arts Park</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Beale Street (Memphis, Tenn.)</field>
+<field name="value">Politics</field>
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Mark Flanagan, 2011</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110402_Mark_Flanagan.PNG.jpg</field>
+<field name="originalName">20110402_Mark_Flanagan.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6609</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33584/3/20110402_Mark_Flanagan.PNG.jpg</field>
+<field name="checksum">d76648384acd04ac0b9e51343ec09f74</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20110402_Mark_Flanagan.pdf.jpg</field>
+<field name="originalName">20110402_Mark_Flanagan.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12437</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33584/6/20110402_Mark_Flanagan.pdf.jpg</field>
+<field name="checksum">21999b55dac01bc5e9555cb0b4ab77da</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110402_Mark_Flanagan.PNG.preview.jpg</field>
+<field name="originalName">20110402_Mark_Flanagan.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">27298</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33584/4/20110402_Mark_Flanagan.PNG.preview.jpg</field>
+<field name="checksum">fd5ec208aad7354b44019d2319141b11</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110402_Mark_Flanagan.pdf.txt</field>
+<field name="originalName">20110402_Mark_Flanagan.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">26757</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33584/5/20110402_Mark_Flanagan.pdf.txt</field>
+<field name="checksum">4b0cf4a931beb0ca2a7a67ccab3b3909</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20110402_Mark_Flanagan.PNG</field>
+<field name="originalName">20110402_Mark_Flanagan.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1142585</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33584/1/20110402_Mark_Flanagan.PNG</field>
+<field name="checksum">f527a5b9b404de2d87430151945ec1b5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20110402_Mark_Flanagan.pdf</field>
+<field name="originalName">20110402_Mark_Flanagan.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">182182</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33584/2/20110402_Mark_Flanagan.pdf</field>
+<field name="checksum">e5e2a0829097539e7d3171843d42b6bf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33584</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33584</field>
+<field name="lastModifyDate">2018-07-12 13:20:40.634</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33363</identifier><datestamp>2018-07-17T16:53:43Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Burrows, Margaret</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:34Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:34Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-06-26</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33363</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130626_Margaret_Burrows</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Memphis native Margaret Burrows shares her experiences growing up in the Highland Heights area.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280398059</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Margaret Burrows, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_Margaret_Burrows.PNG</field>
+<field name="originalName">20130626_Margaret_Burrows.PNG</field>
+<field name="format">image/png</field>
+<field name="size">272490</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33363/1/20130626_Margaret_Burrows.PNG</field>
+<field name="checksum">d95975a5394d809176c0df03e69f3986</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_Margaret_Burrows.pdf</field>
+<field name="originalName">20130626_Margaret_Burrows.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">165854</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33363/2/20130626_Margaret_Burrows.pdf</field>
+<field name="checksum">4ec5c431e554c9355c52ebe62eefda34</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_Margaret_Burrows.PNG.jpg</field>
+<field name="originalName">20130626_Margaret_Burrows.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7756</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33363/3/20130626_Margaret_Burrows.PNG.jpg</field>
+<field name="checksum">fd611c76f52ba1b0c284f9d0c0463416</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130626_Margaret_Burrows.pdf.jpg</field>
+<field name="originalName">20130626_Margaret_Burrows.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12398</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33363/6/20130626_Margaret_Burrows.pdf.jpg</field>
+<field name="checksum">3740a2e137d9173f343e49e3a8c9bb27</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_Margaret_Burrows.PNG.preview.jpg</field>
+<field name="originalName">20130626_Margaret_Burrows.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">17313</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33363/4/20130626_Margaret_Burrows.PNG.preview.jpg</field>
+<field name="checksum">26a2a9ec552c56e9549c6686336bab39</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130626_Margaret_Burrows.pdf.txt</field>
+<field name="originalName">20130626_Margaret_Burrows.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">26395</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33363/5/20130626_Margaret_Burrows.pdf.txt</field>
+<field name="checksum">e72a5be7757064957ab4bd9c4a959146</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33363</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33363</field>
+<field name="lastModifyDate">2018-07-17 11:53:43.094</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33706</identifier><datestamp>2018-07-26T16:43:08Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Hass, Marjorie, 1965-</field>
+<field name="value">Threatt, Brittney M.</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-06-12T15:31:01Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-06-12T15:31:01Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2017-08-07</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33706</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20170807_President_Marjorie_Hass</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, new President Marjorie Hass of Rhodes College reflects on her past experiences and what she hopes to accomplish at Rhodes. Interviewed by Brittney Threatt ('17).</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278587718</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Rhodes College</field>
+<field name="value">Education</field>
+<field name="value">2017 Summer</field>
+<field name="value">Class of 2017</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">President Marjorie Hass, 2017</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170807_President_Marjorie_Hass.JPG.jpg</field>
+<field name="originalName">20170807_President_Marjorie_Hass.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7998</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33706/2/20170807_President_Marjorie_Hass.JPG.jpg</field>
+<field name="checksum">4185bf550e00c843a45445446a211f1c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20170807_President_Marjorie_Hass.pdf.jpg</field>
+<field name="originalName">20170807_President_Marjorie_Hass.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11403</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33706/6/20170807_President_Marjorie_Hass.pdf.jpg</field>
+<field name="checksum">7f2988dbca93d993864fd47f49c7b9e9</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170807_President_Marjorie_Hass.JPG.preview.jpg</field>
+<field name="originalName">20170807_President_Marjorie_Hass.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">30627</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33706/3/20170807_President_Marjorie_Hass.JPG.preview.jpg</field>
+<field name="checksum">70bb28070ebb7be225e47638bf12fef2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170807_President_Marjorie_Hass.pdf.txt</field>
+<field name="originalName">20170807_President_Marjorie_Hass.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">45793</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33706/5/20170807_President_Marjorie_Hass.pdf.txt</field>
+<field name="checksum">461f777c7aa2fdcca06fe106a4da09d7</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20170807_President_Marjorie_Hass.JPG</field>
+<field name="originalName">20170807_President_Marjorie_Hass.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">61488</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33706/1/20170807_President_Marjorie_Hass.JPG</field>
+<field name="checksum">92889af067b3915755fcf6b8840fdb0d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20170807_President_Marjorie_Hass.pdf</field>
+<field name="originalName">20170807_President_Marjorie_Hass.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">161822</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33706/4/20170807_President_Marjorie_Hass.pdf</field>
+<field name="checksum">5822139e99f757c6590dbea6ecdaca03</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33706</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33706</field>
+<field name="lastModifyDate">2018-07-26 11:43:08.287</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33666</identifier><datestamp>2018-07-12T18:20:40Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Lane, James Hunter, Jr.</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T20:59:23Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T20:59:23Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2008-07-22</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33666</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20080722_James_Hunter_Lane</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with James Hunter Lane, Jr. In the interview he describes growing up in Memphis and his involvement in Memphis politics. This involvement included running for mayor in 1967 and serving as president of the school board in 1973, when Memphis City schools were integrated.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="none">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/278571845</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Politics</field>
+<field name="value">Civil rights</field>
+<field name="value">School integration</field>
+<field name="value">Education</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Memphis City Schools</field>
+<field name="value">Race relations</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">James Hunter Lane, 2008</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080722_James_Hunter_Lane.JPG.jpg</field>
+<field name="originalName">20080722_James_Hunter_Lane.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11693</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33666/3/20080722_James_Hunter_Lane.JPG.jpg</field>
+<field name="checksum">999702fde72567e510e94a6138f3c902</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20080722_James_Hunter_Lane.pdf.jpg</field>
+<field name="originalName">20080722_James_Hunter_Lane.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10314</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33666/6/20080722_James_Hunter_Lane.pdf.jpg</field>
+<field name="checksum">db826f0eec8e96b2367f6a04409e81bc</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080722_James_Hunter_Lane.JPG.preview.jpg</field>
+<field name="originalName">20080722_James_Hunter_Lane.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">44348</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33666/4/20080722_James_Hunter_Lane.JPG.preview.jpg</field>
+<field name="checksum">01641e0a64b595779edcbf6579634f15</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080722_James_Hunter_Lane.pdf.txt</field>
+<field name="originalName">20080722_James_Hunter_Lane.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">62878</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33666/5/20080722_James_Hunter_Lane.pdf.txt</field>
+<field name="checksum">fe8b286603cdf7229b6d61a2073352f3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080722_James_Hunter_Lane.JPG</field>
+<field name="originalName">20080722_James_Hunter_Lane.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">96190</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33666/1/20080722_James_Hunter_Lane.JPG</field>
+<field name="checksum">46de78ba1de34a42b8ed8efb85f4b926</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20080722_James_Hunter_Lane.pdf</field>
+<field name="originalName">20080722_James_Hunter_Lane.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">257449</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33666/2/20080722_James_Hunter_Lane.pdf</field>
+<field name="checksum">2fc32a14a2565655e783dcd69bbe90e0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33666</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33666</field>
+<field name="lastModifyDate">2018-07-12 13:20:40.775</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33474</identifier><datestamp>2018-07-18T16:38:15Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Avery, Will Ann</field>
+<field name="value">Benson, Zahria</field>
+<field name="value">Mays, Briana</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-16T16:46:34Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-16T16:46:34Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2015-06-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33474</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20150617_Will_Ann_Avery</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Will Ann Avery grew up in North Carolina and lived in between there and Lake County before she settled down to teach in 1960. She talks about teaching during segregation in Tennessee.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280577850</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Lake County (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Education</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Will Ann Avery, 2015</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150617_Will_Ann_Avery.JPG</field>
+<field name="originalName">20150617_Will_Ann_Avery.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">45661</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33474/1/20150617_Will_Ann_Avery.JPG</field>
+<field name="checksum">8e091879f6c63a10feaeedd10cf37716</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20150617_Will_Ann_Avery.pdf</field>
+<field name="originalName">20150617_Will_Ann_Avery.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">279909</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33474/2/20150617_Will_Ann_Avery.pdf</field>
+<field name="checksum">86025d70f09f368535b12f27a8ae393f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150617_Will_Ann_Avery.JPG.jpg</field>
+<field name="originalName">20150617_Will_Ann_Avery.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">5925</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33474/3/20150617_Will_Ann_Avery.JPG.jpg</field>
+<field name="checksum">d8b2ebff6c87f4c5e631b4d804eeeb64</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20150617_Will_Ann_Avery.pdf.jpg</field>
+<field name="originalName">20150617_Will_Ann_Avery.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12032</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33474/6/20150617_Will_Ann_Avery.pdf.jpg</field>
+<field name="checksum">dfc51a87f7af1c660620f68f422dba99</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150617_Will_Ann_Avery.JPG.preview.jpg</field>
+<field name="originalName">20150617_Will_Ann_Avery.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">21445</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33474/4/20150617_Will_Ann_Avery.JPG.preview.jpg</field>
+<field name="checksum">0b0be381bde394cf9960f82edc6a68cd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150617_Will_Ann_Avery.pdf.txt</field>
+<field name="originalName">20150617_Will_Ann_Avery.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">12389</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33474/5/20150617_Will_Ann_Avery.pdf.txt</field>
+<field name="checksum">19bf3718bb27bfdfd35a13d013722fc8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33474</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33474</field>
+<field name="lastModifyDate">2018-07-18 11:38:15.572</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33540</identifier><datestamp>2018-07-17T18:02:11Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Foote, Huger</field>
+<field name="value">Huebner, Timothy S.</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T14:48:50Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T14:48:50Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-11-14</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33540</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20131114_Huger_Foote</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">In this interview, Huger Foote, son of Shelby Foote, discusses his and his father's careers. Interviewee: Huger Foote Interviewer: Tim Huebner Date: November 14, 2013</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280408765</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Foote, Shelby</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Huger Foote, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20131114_Huger_Foote.PNG.jpg</field>
+<field name="originalName">20131114_Huger_Foote.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8540</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33540/3/20131114_Huger_Foote.PNG.jpg</field>
+<field name="checksum">656e74ead56b1bfff3ac209b9f761993</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20131114_Huger_Foote.pdf.jpg</field>
+<field name="originalName">20131114_Huger_Foote.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13098</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33540/6/20131114_Huger_Foote.pdf.jpg</field>
+<field name="checksum">1d6ef4d41d20774b36d399c516e7883c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20131114_Huger_Foote.PNG.preview.jpg</field>
+<field name="originalName">20131114_Huger_Foote.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">30927</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33540/4/20131114_Huger_Foote.PNG.preview.jpg</field>
+<field name="checksum">40f0a2c2f229a0ceec5c2cdc0b39a566</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20131114_Huger_Foote.pdf.txt</field>
+<field name="originalName">20131114_Huger_Foote.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">48649</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33540/5/20131114_Huger_Foote.pdf.txt</field>
+<field name="checksum">3b6159d75f2c413aa20c05b0ce364221</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20131114_Huger_Foote.PNG</field>
+<field name="originalName">20131114_Huger_Foote.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1486999</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33540/1/20131114_Huger_Foote.PNG</field>
+<field name="checksum">a3a82f9d5c55fbc73ccf8d391d69bb66</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20131114_Huger_Foote.pdf</field>
+<field name="originalName">20131114_Huger_Foote.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">204588</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33540/2/20131114_Huger_Foote.pdf</field>
+<field name="checksum">ea35bcfe71236099cb2af1becd922774</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33540</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33540</field>
+<field name="lastModifyDate">2018-07-17 13:02:11.902</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33382</identifier><datestamp>2018-07-12T18:20:40Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Morton, Fred</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:37Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:37Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-07-16</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33382</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140716_Fred_Morton</field>
+</element>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279544993</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Fred Morton, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140716_Fred_Morton.txt.txt</field>
+<field name="originalName">20140716_Fred_Morton.txt.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">6979</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33382/7/20140716_Fred_Morton.txt.txt</field>
+<field name="checksum">fbe246626c0205e8a675dc6f7ed6e1af</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140716_Fred_Morton</field>
+<field name="originalName">20140716_Fred_Morton</field>
+<field name="format">image/jpeg</field>
+<field name="size">16841</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33382/1/20140716_Fred_Morton</field>
+<field name="checksum">a9c06e6a640ea9fd78ec68fdf1d3d0bd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20140716_Fred_Morton.txt</field>
+<field name="originalName">20140716_Fred_Morton.txt</field>
+<field name="format">text/plain</field>
+<field name="size">7479</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33382/6/20140716_Fred_Morton.txt</field>
+<field name="checksum">7cbddbed8355d58cf0d9006943288720</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.JPG.jpg</field>
+<field name="originalName">Capture.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">5520</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33382/2/Capture.JPG.jpg</field>
+<field name="checksum">0de3824f774049a72fd797d68b0d1982</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20140716_Fred_Morton.jpg</field>
+<field name="originalName">20140716_Fred_Morton.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">5520</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33382/4/20140716_Fred_Morton.jpg</field>
+<field name="checksum">0de3824f774049a72fd797d68b0d1982</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.JPG.preview.jpg</field>
+<field name="originalName">Capture.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">10905</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33382/3/Capture.JPG.preview.jpg</field>
+<field name="checksum">2e6e5e33fbb00a947da6f045fa789e00</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140716_Fred_Morton.preview.jpg</field>
+<field name="originalName">20140716_Fred_Morton.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">10905</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33382/5/20140716_Fred_Morton.preview.jpg</field>
+<field name="checksum">2e6e5e33fbb00a947da6f045fa789e00</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33382</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33382</field>
+<field name="lastModifyDate">2018-07-12 13:20:40.807</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33358</identifier><datestamp>2018-07-17T16:31:00Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">McKinney, Darryl</field>
+<field name="value">Hibbert, Caroline</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:32Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:32Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-06-19</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33358</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130619_Darryl_Mckinney</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Darryl McKinny was born in Memphis, TN in 1980. He lived in the Binghamton area until he was eight years old, and then his family moved to Highland Heights. Darryl McKinny strives to help people and the youth of the community, either through the ministry or at the juvenile facility. Darryl is a pastor of evangelism at the Two Cornerstone Church. During the day he is working on getting his masters in ministry. At night he works at Youth Dimensions which is a juvenile facility that handles children from the state. Darryl is on the direct counsel at Youth Dimensions, he interacts with the youth all day long. His job is to monitor their behavior, correct them, redirect them, and make sure they are headed in the best direction. "In turn, I now go back to the neighborhood and tell them, 'Hey, you can do this.'" -Darryl Mckinny</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280394197</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Darryl McKinney, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130619_Darryl_Mckinney.JPG</field>
+<field name="originalName">20130619_Darryl_Mckinney.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">47188</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33358/1/20130619_Darryl_Mckinney.JPG</field>
+<field name="checksum">c28d51b373cd51cff38ca66a8bb983e3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130619_Darryl_Mckinney.pdf</field>
+<field name="originalName">20130619_Darryl_Mckinney.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">160432</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33358/4/20130619_Darryl_Mckinney.pdf</field>
+<field name="checksum">3b54f182f118bbf52ff5143a5a0b394c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.JPG.jpg</field>
+<field name="originalName">Capture.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9713</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33358/2/Capture.JPG.jpg</field>
+<field name="checksum">31441a5cf3eb215cc27e6f10775448a8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20130619_Darryl_Mckinney.pdf.jpg</field>
+<field name="originalName">20130619_Darryl_Mckinney.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11834</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33358/6/20130619_Darryl_Mckinney.pdf.jpg</field>
+<field name="checksum">aefa817fe98bede2a6bac47be2c6ac4a</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20130619_Darryl_Mckinney.JPG.jpg</field>
+<field name="originalName">20130619_Darryl_Mckinney.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">9713</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33358/7/20130619_Darryl_Mckinney.JPG.jpg</field>
+<field name="checksum">31441a5cf3eb215cc27e6f10775448a8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.JPG.preview.jpg</field>
+<field name="originalName">Capture.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">29600</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33358/3/Capture.JPG.preview.jpg</field>
+<field name="checksum">c4f881af10edcbf71d473ab65ac52518</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130619_Darryl_Mckinney.JPG.preview.jpg</field>
+<field name="originalName">20130619_Darryl_Mckinney.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">29600</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33358/8/20130619_Darryl_Mckinney.JPG.preview.jpg</field>
+<field name="checksum">c4f881af10edcbf71d473ab65ac52518</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130619_Darryl_Mckinney.pdf.txt</field>
+<field name="originalName">20130619_Darryl_Mckinney.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">28653</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33358/5/20130619_Darryl_Mckinney.pdf.txt</field>
+<field name="checksum">82c10ccacb94a2b43661a4ae37e8b255</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33358</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33358</field>
+<field name="lastModifyDate">2018-07-17 11:31:00.724</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33490</identifier><datestamp>2018-06-15T18:37:20Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Ramsey, Brooks</field>
+<field name="value">Schultz, Judy</field>
+<field name="value">Beifuss, Joan</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-18T15:23:55Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-18T15:23:55Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2007-06-06</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33490</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20070606_Brooks_Ramsey</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Brooks Ramsey, who gained national popularity during the 1960s while serving as the Pastor of First Baptist Church in Albany, Georgia. When some of his ushers prevented three black men from entering his church Ramsey publicly denounced the incident. After this controversial incident Ramsey moved to Memphis where his progressive, ecumenical views once again left him at odds with his congregation. Ramsey currently counsels individuals from his home. Our collection also includes an audio interview with Rev. Ramsey conducted in 1968.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://www.youtube.com/watch?v=-f2p9ZxLfXs</field>
+<field name="value">https://youtu.be/-f2p9ZxLfXs</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Civil rights</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+<field name="value">Race relations</field>
+<field name="value">King, Martin Luther, Jr., 1929-1968</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Brooks Ramsey, 2007</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070606_Brooks_Ramsey.pdf</field>
+<field name="originalName">20070606_Brooks_Ramsey.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">221218</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33490/1/20070606_Brooks_Ramsey.pdf</field>
+<field name="checksum">69238dd6d9b3608fb05dbbbd8d35f6e2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20070606_Brooks_Ramsey.jpg</field>
+<field name="originalName">20070606_Brooks_Ramsey.jpg</field>
+<field name="format">image/jpeg</field>
+<field name="size">149256</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33490/4/20070606_Brooks_Ramsey.jpg</field>
+<field name="checksum">c747c1212aeaebbd78947c1319a52fcf</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070606_Brooks_Ramsey.pdf.txt</field>
+<field name="originalName">20070606_Brooks_Ramsey.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">57145</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33490/2/20070606_Brooks_Ramsey.pdf.txt</field>
+<field name="checksum">325a44733f96b52b7282884559068de8</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070606_Brooks_Ramsey.pdf.jpg</field>
+<field name="originalName">20070606_Brooks_Ramsey.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11605</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33490/3/20070606_Brooks_Ramsey.pdf.jpg</field>
+<field name="checksum">39a674b57bb03a8f3e5ea53804b5472d</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20070606_Brooks_Ramsey.jpg.jpg</field>
+<field name="originalName">20070606_Brooks_Ramsey.jpg.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11056</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33490/5/20070606_Brooks_Ramsey.jpg.jpg</field>
+<field name="checksum">05f5cefd336828afe514c567504d97d4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20070606_Brooks_Ramsey.jpg.preview.jpg</field>
+<field name="originalName">20070606_Brooks_Ramsey.jpg.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">41101</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33490/6/20070606_Brooks_Ramsey.jpg.preview.jpg</field>
+<field name="checksum">ea7cd1487829666bc30682e5291a6074</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33490</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33490</field>
+<field name="lastModifyDate">2018-06-15 13:37:20.842</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/30943</identifier><datestamp>2018-07-26T21:24:37Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Svgdik, Dorothy</field>
+<field name="value">Astor, Vincent</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2017-12-08T17:32:40Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2017-12-08T17:32:40Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-04-03</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/30943</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130403_Vincent_Astor</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Interviewer: Dorothy Svgdik&#xd;
+Interviewee: Mr. Vincent Astor&#xd;
+Date: 2013-04-03&#xd;
+Location: Rhodes College, Memphis, TN</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/281664812</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">LGBTQ Community</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Vincent Astor, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130403_Vincent_Astor_LGBT.pdf</field>
+<field name="originalName">20130403_Vincent_Astor_LGBT.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">306762</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30943/1/20130403_Vincent_Astor_LGBT.pdf</field>
+<field name="checksum">eae24cc76392aaf8d882ed23f7a5efff</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130403_Vincent_Astor_LGBT.JPG</field>
+<field name="originalName">20130403_Vincent_Astor_LGBT.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">37315</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30943/2/20130403_Vincent_Astor_LGBT.JPG</field>
+<field name="checksum">5e977ccd8dcc7e70758d5f010435f345</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130403_Vincent_Astor_LGBT.pdf.txt</field>
+<field name="originalName">20130403_Vincent_Astor_LGBT.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">51052</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30943/3/20130403_Vincent_Astor_LGBT.pdf.txt</field>
+<field name="checksum">62bc34cb3f7103d0376a5a1af3cbad50</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130403_Vincent_Astor_LGBT.pdf.jpg</field>
+<field name="originalName">20130403_Vincent_Astor_LGBT.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12885</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30943/4/20130403_Vincent_Astor_LGBT.pdf.jpg</field>
+<field name="checksum">ddb8c707ec43a13f8929ea4aa485d16c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">2013_vincent_astor.JPG.jpg</field>
+<field name="originalName">2013_vincent_astor.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7425</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30943/5/2013_vincent_astor.JPG.jpg</field>
+<field name="checksum">d622fe11217d91e00b992174d96b9ae4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+<element name="bitstream">
+<field name="name">20130403_Vincent_Astor_LGBT.JPG.jpg</field>
+<field name="originalName">20130403_Vincent_Astor_LGBT.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7425</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30943/7/20130403_Vincent_Astor_LGBT.JPG.jpg</field>
+<field name="checksum">d622fe11217d91e00b992174d96b9ae4</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">2013_vincent_astor.JPG.preview.jpg</field>
+<field name="originalName">2013_vincent_astor.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">22722</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30943/6/2013_vincent_astor.JPG.preview.jpg</field>
+<field name="checksum">fd70f8502618925062b46b1b5c846dc6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20130403_Vincent_Astor_LGBT.JPG.preview.jpg</field>
+<field name="originalName">20130403_Vincent_Astor_LGBT.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">22722</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30943/8/20130403_Vincent_Astor_LGBT.JPG.preview.jpg</field>
+<field name="checksum">fd70f8502618925062b46b1b5c846dc6</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/30943</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/30943</field>
+<field name="lastModifyDate">2018-07-26 16:24:37.653</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/30946</identifier><datestamp>2018-07-19T20:15:23Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Hughes, Charles L.</field>
+<field name="value">Mackenzie, Susan</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2017-12-08T17:32:40Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2017-12-08T17:32:40Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2016-07-14</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/30946</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20160714_Susan_Mackenzie</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Susan Mackenzie on July 14th, 2016.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280797836</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">LGBTQ Community</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Susan Mackenzie, 2016</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20160714_Susan_Mackenzie.JPG</field>
+<field name="originalName">20160714_Susan_Mackenzie.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">35111</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30946/1/20160714_Susan_Mackenzie.JPG</field>
+<field name="checksum">98838d7c83d9bace62bd1328e43919e5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20160714_Susan_Mackenzie.pdf</field>
+<field name="originalName">20160714_Susan_Mackenzie.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">250382</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30946/2/20160714_Susan_Mackenzie.pdf</field>
+<field name="checksum">1b62358d765064695cb7f8a1a2a53fe5</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">2016_susan_mackenzie.JPG.jpg</field>
+<field name="originalName">2016_susan_mackenzie.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7869</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30946/3/2016_susan_mackenzie.JPG.jpg</field>
+<field name="checksum">6d346b7e0d1de21e8005e734039e4050</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20160714_Susan_Mackenzie.pdf.jpg</field>
+<field name="originalName">20160714_Susan_Mackenzie.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13337</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30946/5/20160714_Susan_Mackenzie.pdf.jpg</field>
+<field name="checksum">eac71ed3aebce658dae6a3fe8390654e</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+<element name="bitstream">
+<field name="name">20160714_Susan_Mackenzie.JPG.jpg</field>
+<field name="originalName">20160714_Susan_Mackenzie.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7869</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30946/7/20160714_Susan_Mackenzie.JPG.jpg</field>
+<field name="checksum">6d346b7e0d1de21e8005e734039e4050</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20160714_Susan_Mackenzie.pdf.txt</field>
+<field name="originalName">20160714_Susan_Mackenzie.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">40006</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30946/4/20160714_Susan_Mackenzie.pdf.txt</field>
+<field name="checksum">b47da654c67c67f34cf81251249ca490</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">2016_susan_mackenzie.JPG.preview.jpg</field>
+<field name="originalName">2016_susan_mackenzie.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">22923</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30946/6/2016_susan_mackenzie.JPG.preview.jpg</field>
+<field name="checksum">e316d1aff62f5c5e7d3a16ffc392a4dd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20160714_Susan_Mackenzie.JPG.preview.jpg</field>
+<field name="originalName">20160714_Susan_Mackenzie.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">22923</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30946/8/20160714_Susan_Mackenzie.JPG.preview.jpg</field>
+<field name="checksum">e316d1aff62f5c5e7d3a16ffc392a4dd</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/30946</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/30946</field>
+<field name="lastModifyDate">2018-07-19 15:15:23.997</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33389</identifier><datestamp>2018-07-26T21:26:59Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Khan, Iqbal</field>
+<field name="value">Khan, Irem</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-01T15:16:30Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-01T15:16:30Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2014-07-14</field>
+</element>
+</element>
+<element name="graduation">
+<element name="none">
+<field name="value">2014</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33389</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20140714_Iqbal_Khan</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Collection: Islam in Memphis Oral Histories, Interviewees: Iqbal Khan, Date: 2014-07-14</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/281666958</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Islam</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Religion</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Iqbal Khan, 2014</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140714_Iqbal_Khan</field>
+<field name="originalName">20140714_Iqbal_Khan</field>
+<field name="format">image/png</field>
+<field name="size">1073569</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33389/3/20140714_Iqbal_Khan</field>
+<field name="checksum">ba1da716257dccb7d8babb1c42f2030c</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20140714_Iqbal_Khan.pdf</field>
+<field name="originalName">20140714_Iqbal_Khan.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">226917</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33389/6/20140714_Iqbal_Khan.pdf</field>
+<field name="checksum">ae39a223758a48b015e61bf83c7a49ed</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140714_Iqbal_Khan.doc.txt</field>
+<field name="originalName">20140714_Iqbal_Khan.doc.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">53424</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33389/2/20140714_Iqbal_Khan.doc.txt</field>
+<field name="checksum">d26fa7e8c789aa4213e20999a1c6b004</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20140714_Iqbal_Khan.pdf.txt</field>
+<field name="originalName">20140714_Iqbal_Khan.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">56602</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33389/7/20140714_Iqbal_Khan.pdf.txt</field>
+<field name="checksum">ec6e935605e9e905d9c520a0ab7129cb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140714_Iqbal_Khan.jpg</field>
+<field name="originalName">20140714_Iqbal_Khan.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">6348</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33389/4/20140714_Iqbal_Khan.jpg</field>
+<field name="checksum">83996eb9b46328b124da1833af10e171</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20140714_Iqbal_Khan.pdf.jpg</field>
+<field name="originalName">20140714_Iqbal_Khan.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12938</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33389/8/20140714_Iqbal_Khan.pdf.jpg</field>
+<field name="checksum">0cb63ecdf422cf03663f847841cb8b44</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20140714_Iqbal_Khan.preview.jpg</field>
+<field name="originalName">20140714_Iqbal_Khan.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">23931</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33389/5/20140714_Iqbal_Khan.preview.jpg</field>
+<field name="checksum">1bb91d37c828e0cb4125b4a5d507a431</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33389</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33389</field>
+<field name="lastModifyDate">2018-07-26 16:26:59.483</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/30945</identifier><datestamp>2018-07-19T20:26:24Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Hughes, Charles L.</field>
+<field name="value">Johnston, Hunter</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2017-12-08T17:32:40Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2017-12-08T17:32:40Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2016-07-22</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/30945</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20160722_Hunter_Johnston</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Date: July 22, 2016&#xd;
+Interviewer: Dr. Charles Hughes&#xd;
+Interviewee: Hunter Johnston&#xd;
+Location: Rhodes College, Memphis, TN</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280798650</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">LGBTQ Community</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Hunter Johnston, 2016</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20160722_Hunter_Johnston.JPG</field>
+<field name="originalName">20160722_Hunter_Johnston.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">35657</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30945/1/20160722_Hunter_Johnston.JPG</field>
+<field name="checksum">8c1de50db74415b304c23df6ffd76987</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20160722_Hunter_Johnston.pdf</field>
+<field name="originalName">20160722_Hunter_Johnston.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">370721</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30945/2/20160722_Hunter_Johnston.pdf</field>
+<field name="checksum">d6547e8a5e99f8376642d367fc0b644b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">2016_hunter_johnston.JPG.jpg</field>
+<field name="originalName">2016_hunter_johnston.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7843</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30945/3/2016_hunter_johnston.JPG.jpg</field>
+<field name="checksum">04dd9f5b286fa608cd9dfdf1fd0d9eb2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20160722_Hunter_Johnston.pdf.jpg</field>
+<field name="originalName">20160722_Hunter_Johnston.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12808</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30945/5/20160722_Hunter_Johnston.pdf.jpg</field>
+<field name="checksum">ddfa8ea584c6fdda633b5a20fd5d4818</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+<element name="bitstream">
+<field name="name">20160722_Hunter_Johnston.JPG.jpg</field>
+<field name="originalName">20160722_Hunter_Johnston.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">7843</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30945/7/20160722_Hunter_Johnston.JPG.jpg</field>
+<field name="checksum">04dd9f5b286fa608cd9dfdf1fd0d9eb2</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20160722_Hunter_Johnston.pdf.txt</field>
+<field name="originalName">20160722_Hunter_Johnston.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">69031</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30945/4/20160722_Hunter_Johnston.pdf.txt</field>
+<field name="checksum">548db537d0db8d60247715fd62ba4e0f</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">2016_hunter_johnston.JPG.preview.jpg</field>
+<field name="originalName">2016_hunter_johnston.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">22688</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30945/6/2016_hunter_johnston.JPG.preview.jpg</field>
+<field name="checksum">608d255bd822e7c2eb1bc5342e17c836</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20160722_Hunter_Johnston.JPG.preview.jpg</field>
+<field name="originalName">20160722_Hunter_Johnston.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">22688</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/30945/8/20160722_Hunter_Johnston.JPG.preview.jpg</field>
+<field name="checksum">608d255bd822e7c2eb1bc5342e17c836</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/30945</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/30945</field>
+<field name="lastModifyDate">2018-07-19 15:26:24.999</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33535</identifier><datestamp>2018-07-17T17:07:42Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Ives, Elliott</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-21T14:48:48Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-21T14:48:48Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2013-07-05</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33535</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20130705_Elliot_Ives</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Elliott Ives speaks about his experience playing in Memphis bands while attending Memphis University School and Rhodes College, becoming a producer and running the Young Avenue Sound studio, deciding whether to sign with Universal or Stax under Justin Timberlake, and making it big. Interview conducted on July 5, 2013.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280400367</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Oral history</field>
+<field name="value">Interviews</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Music</field>
+<field name="value">Rhodes College</field>
+<field name="value">Memphis University School</field>
+<field name="value">UNI Records (Sound recording label)</field>
+<field name="value">Stax Records</field>
+<field name="value">Timberlake, Justin, 1981-</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Elliott Ives, 2013</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130705_Elliot_Ives.PNG</field>
+<field name="originalName">20130705_Elliot_Ives.PNG</field>
+<field name="format">image/png</field>
+<field name="size">1571211</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33535/1/20130705_Elliot_Ives.PNG</field>
+<field name="checksum">51166a82b2013981d508e26ce6648b09</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20130705_Elliot_Ives.pdf</field>
+<field name="originalName">20130705_Elliot_Ives.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">279811</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33535/4/20130705_Elliot_Ives.pdf</field>
+<field name="checksum">022b96ef5313a2bd7dc437572e544541</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.PNG.jpg</field>
+<field name="originalName">Capture.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8319</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33535/2/Capture.PNG.jpg</field>
+<field name="checksum">d0fa1ec0fda4bbf92dcc5656ab421b78</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+<element name="bitstream">
+<field name="name">20130705_Elliot_Ives.PNG.jpg</field>
+<field name="originalName">20130705_Elliot_Ives.PNG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8319</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33535/5/20130705_Elliot_Ives.PNG.jpg</field>
+<field name="checksum">d0fa1ec0fda4bbf92dcc5656ab421b78</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+<element name="bitstream">
+<field name="name">20130705_Elliot_Ives.pdf.jpg</field>
+<field name="originalName">20130705_Elliot_Ives.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">12157</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33535/8/20130705_Elliot_Ives.pdf.jpg</field>
+<field name="checksum">bf2dd79d46d9c1231238c1227ec04844</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.PNG.preview.jpg</field>
+<field name="originalName">Capture.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">30226</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33535/3/Capture.PNG.preview.jpg</field>
+<field name="checksum">7d72c0b9571dd5760aa7db2525761ea3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20130705_Elliot_Ives.PNG.preview.jpg</field>
+<field name="originalName">20130705_Elliot_Ives.PNG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">30226</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33535/6/20130705_Elliot_Ives.PNG.preview.jpg</field>
+<field name="checksum">7d72c0b9571dd5760aa7db2525761ea3</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20130705_Elliot_Ives.pdf.txt</field>
+<field name="originalName">20130705_Elliot_Ives.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">43324</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33535/7/20130705_Elliot_Ives.pdf.txt</field>
+<field name="checksum">748b1ecea15ec56235bac43a9737c1bb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33535</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33535</field>
+<field name="lastModifyDate">2018-07-17 12:07:42.157</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33650</identifier><datestamp>2018-07-12T18:20:40Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Cox, Dorothy</field>
+<field name="value">Turner, Lauren</field>
+<field name="value">Jenkins, Brittany (Britt)</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-05-30T20:59:20Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-05-30T20:59:20Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2008-05-30</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33650</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20080530_Dorothy_Cox</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">This is an interview with Dorothy Cox, who is currently the Project Manager for the Rhodes Hollywood-Springdale Partnership. She is an avid community leader and works diligently to preserve a sense of community and genuine humanity. She discusses racism in terms of economic inequality and the ambiguity of discrimination as it exists today.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="none">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/279475359</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Crossroads to Freedom</field>
+<field name="value">Hollywood-Hyde Park-Springdale (Memphis, Tenn.)</field>
+<field name="value">Race relations</field>
+<field name="value">African Americans</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Dorothy Cox, 2008</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080530_Dorothy_Cox.JPG</field>
+<field name="originalName">20080530_Dorothy_Cox.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">74332</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33650/1/20080530_Dorothy_Cox.JPG</field>
+<field name="checksum">d01e35a5f830281ae4d11e28a82bb169</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20080530_Dorothy_Cox.pdf</field>
+<field name="originalName">20080530_Dorothy_Cox.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">354129</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33650/2/20080530_Dorothy_Cox.pdf</field>
+<field name="checksum">2645134bd93489680f290cb941728c42</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080530_Dorothy_Cox.JPG.jpg</field>
+<field name="originalName">20080530_Dorothy_Cox.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">8925</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33650/3/20080530_Dorothy_Cox.JPG.jpg</field>
+<field name="checksum">10438626ad66d7ace4601d4cbf585a12</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20080530_Dorothy_Cox.pdf.jpg</field>
+<field name="originalName">20080530_Dorothy_Cox.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">13355</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33650/6/20080530_Dorothy_Cox.pdf.jpg</field>
+<field name="checksum">505913ce201b6fff5c93bc6219fd13bb</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080530_Dorothy_Cox.JPG.preview.jpg</field>
+<field name="originalName">20080530_Dorothy_Cox.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">33472</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33650/4/20080530_Dorothy_Cox.JPG.preview.jpg</field>
+<field name="checksum">1183c06532a6cc6712646d67a6a5a1f0</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20080530_Dorothy_Cox.pdf.txt</field>
+<field name="originalName">20080530_Dorothy_Cox.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">68634</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33650/5/20080530_Dorothy_Cox.pdf.txt</field>
+<field name="checksum">45b2718fb04929569ddded0b1241c323</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33650</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33650</field>
+<field name="lastModifyDate">2018-07-12 13:20:40.851</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><record><header><identifier>oai:dlynx.rhodes.edu:10267/33347</identifier><datestamp>2018-07-18T16:34:54Z</datestamp><setSpec>com_10267_30688</setSpec><setSpec>col_10267_30936</setSpec></header><metadata><metadata xmlns="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd">
+<element name="dc">
+<element name="contributor">
+<element name="none">
+<field name="value">Spence, Nelle</field>
+<field name="value">Hayes, Layna</field>
+<field name="value">Morris-Loper, Keyonte</field>
+</element>
+</element>
+<element name="date">
+<element name="accessioned">
+<element name="none">
+<field name="value">2018-04-30T20:02:28Z</field>
+</element>
+</element>
+<element name="available">
+<element name="none">
+<field name="value">2018-04-30T20:02:28Z</field>
+</element>
+</element>
+<element name="issued">
+<element name="none">
+<field name="value">2015-06-17</field>
+</element>
+</element>
+</element>
+<element name="identifier">
+<element name="uri">
+<element name="none">
+<field name="value">http://hdl.handle.net/10267/33347</field>
+</element>
+</element>
+<element name="rhodes">
+<element name="none">
+<field name="value">20150617_Nelle_Spence</field>
+</element>
+</element>
+</element>
+<element name="description">
+<element name="none">
+<field name="value">Nelle Spence, born in 1921 and a native Tennessean, moved to Highland Heights in 1940. While living in Highland Heights, she married and had two children, but was later on divorced. Ms. Spence highly values her community and believes that it's the people who make it home. She invests in her community by volunteering at schools, churches and hospitals.</field>
+</element>
+</element>
+<element name="publisher">
+<element name="en_US">
+<field name="value">Rhodes College</field>
+</element>
+</element>
+<element name="relation">
+<element name="uri">
+<element name="none">
+<field name="value">https://vimeo.com/280574057</field>
+</element>
+</element>
+</element>
+<element name="subject">
+<element name="en_US">
+<field name="value">Interviews</field>
+<field name="value">Oral history</field>
+<field name="value">Memphis (Tenn.)</field>
+<field name="value">Civil rights</field>
+<field name="value">Highland Heights (Memphis, Tenn.)</field>
+<field name="value">Neighborhood Histories</field>
+<field name="value">Crossroads to Freedom</field>
+</element>
+</element>
+<element name="title">
+<element name="en_US">
+<field name="value">Nelle Spence, 2015</field>
+</element>
+</element>
+<element name="type">
+<element name="none">
+<field name="value">Moving Image</field>
+</element>
+</element>
+</element>
+<element name="bundles">
+<element name="bundle">
+<field name="name">ORIGINAL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150617_Spence_Nelle.JPG</field>
+<field name="originalName">20150617_Spence_Nelle.JPG</field>
+<field name="format">image/jpeg</field>
+<field name="size">22513</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33347/1/20150617_Spence_Nelle.JPG</field>
+<field name="checksum">3ba1eacf9e916c1724302de3b7aa439b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">1</field>
+</element>
+<element name="bitstream">
+<field name="name">20150617_Spence_Nelle.pdf</field>
+<field name="originalName">20150617_Spence_Nelle.pdf</field>
+<field name="format">application/pdf</field>
+<field name="size">344935</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33347/2/20150617_Spence_Nelle.pdf</field>
+<field name="checksum">559f06483e001cc7de7c765e9b5fa111</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">2</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">THUMBNAIL</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.JPG.jpg</field>
+<field name="originalName">Capture.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10530</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33347/3/Capture.JPG.jpg</field>
+<field name="checksum">de7f1bdce1a2c3b3413a8f5b68ff32ac</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">3</field>
+</element>
+<element name="bitstream">
+<field name="name">20150617_Spence_Nelle.pdf.jpg</field>
+<field name="originalName">20150617_Spence_Nelle.pdf.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">11689</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33347/6/20150617_Spence_Nelle.pdf.jpg</field>
+<field name="checksum">e0545afc17ab909ddd8e935041217347</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">6</field>
+</element>
+<element name="bitstream">
+<field name="name">20150617_Spence_Nelle.JPG.jpg</field>
+<field name="originalName">20150617_Spence_Nelle.JPG.jpg</field>
+<field name="description">Generated Thumbnail</field>
+<field name="format">image/jpeg</field>
+<field name="size">10530</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33347/7/20150617_Spence_Nelle.JPG.jpg</field>
+<field name="checksum">de7f1bdce1a2c3b3413a8f5b68ff32ac</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">7</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">BRANDED_PREVIEW</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">Capture.JPG.preview.jpg</field>
+<field name="originalName">Capture.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">13278</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33347/4/Capture.JPG.preview.jpg</field>
+<field name="checksum">43e4a36a9fdbc34ae0fbf9b283c8a4df</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">4</field>
+</element>
+<element name="bitstream">
+<field name="name">20150617_Spence_Nelle.JPG.preview.jpg</field>
+<field name="originalName">20150617_Spence_Nelle.JPG.preview.jpg</field>
+<field name="description">Generated Branded Preview</field>
+<field name="format">image/jpeg</field>
+<field name="size">13278</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33347/8/20150617_Spence_Nelle.JPG.preview.jpg</field>
+<field name="checksum">43e4a36a9fdbc34ae0fbf9b283c8a4df</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">8</field>
+</element>
+</element>
+</element>
+<element name="bundle">
+<field name="name">TEXT</field>
+<element name="bitstreams">
+<element name="bitstream">
+<field name="name">20150617_Spence_Nelle.pdf.txt</field>
+<field name="originalName">20150617_Spence_Nelle.pdf.txt</field>
+<field name="description">Extracted text</field>
+<field name="format">text/plain</field>
+<field name="size">34729</field>
+<field name="url">http://dlynx.rhodes.edu:8080/jspui/bitstream/10267/33347/5/20150617_Spence_Nelle.pdf.txt</field>
+<field name="checksum">79206911386e641434c3fa9fc1e5823b</field>
+<field name="checksumAlgorithm">MD5</field>
+<field name="sid">5</field>
+</element>
+</element>
+</element>
+</element>
+<element name="others">
+<field name="handle">10267/33347</field>
+<field name="identifier">oai:dlynx.rhodes.edu:10267/33347</field>
+<field name="lastModifyDate">2018-07-18 11:34:54.14</field>
+</element>
+<element name="repository">
+<field name="name">Rhodes College Digital Archives - DLynx</field>
+<field name="mail">newmanj@rhodes.edu</field>
+</element>
+</metadata></metadata></record><resumptionToken completeListSize="321" cursor="0">xoai///col_10267_30936/100</resumptionToken></ListRecords></OAI-PMH>


### PR DESCRIPTION
**GitHub Issue**: [DLTN_XSLT-111](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/111)

* [Metadata mapping](https://dltn-technical-docs.readthedocs.io/en/latest/mappings/crossroads.html#col-10267-30936-crossroads-to-freedom-oral-history-collection)

## What does this Pull Request do?

This pull requests adds a sample record for Rhodes Oral Histories and makes modifications to the default template that work for both Friends and Family and Oral Histories.

## What's new?

* A sample record to test against
* Adds a namespace for local things to keep things simple
* Adds a list of acceptable params for typeOfResource and a matching incoming value
* Changes the thumbnail xpath selector so that only one thumbnail is ever selected
* Creates a default rule for mapping descriptions to abstract.  This will need to be enhanced later.
* Maps a link to the streaming video when something is hosted on vimeo
* Ensures Rhodes College is never listed as publisher
* Changes typeOfResource rule so that a value must match an existing param or nothing happens

## How should this be tested?

1. Run updated stylesheet versus the incoming sample record.
2. Check for validity.
3. Check that mapping table is accurate.


## Additional Notes:

I need to update the mapping table so that the streaming portion is correct.

## Interested parties

@mlhale7 
