### PR TITLE
Addess local namepace issues for UTC and TSLA.

### DIFF
--- a/Sample_Data/State_Library/qdc/Strickland.xml
+++ b/Sample_Data/State_Library/qdc/Strickland.xml
@@ -11,6 +11,7 @@
     <dc:identifier>32924</dc:identifier>
     <dc:type>Still Image</dc:type>
     <dc:format>Image/jp2</dc:format>
+    <dc:language>no linguistic content.</dc:language>
     <dc:rights>While TSLA houses an item, it does not necessarily hold the copyright on the item, nor may it be able to determine if the item is still protected under current copyright law.  Users are solely responsible for determining the existence of such instances and for obtaining any other permissions and paying associated fees that may be necessary for the intended use.</dc:rights>
     <dc:identifier>http://cdm15138.contentdm.oclc.org/cdm/ref/collection/Strickland/id/37</dc:identifier>
 </oai_qdc:qualifieddc>

--- a/XSLT/tslaqdctomods.xsl
+++ b/XSLT/tslaqdctomods.xsl
@@ -5,6 +5,7 @@
     xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
     xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/"
     xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns="http://www.loc.gov/mods/v3"
+    xmlns:dltn="https://github.com/digitallibraryoftennessee"
     xpath-default-namespace="http://worldcat.org/xmlschema/qdc-1.0/"
     exclude-result-prefixes="xs xsi oai oai_qdc dcterms dc" version="2.0">
 
@@ -27,13 +28,13 @@
   -->
 
     <xsl:param name="pLang">
-        <l string="eng">english</l>
-        <l string="eng">en</l>
-        <l string="eng">eng</l>
-        <l string="deu">german</l>
-        <l string="spa">spanish</l>
-        <l string="zxx">zxx</l>
-        <l string="zxx">no linguistic content.</l>
+        <dltn:l string="eng">english</dltn:l>
+        <dltn:l string="eng">en</dltn:l>
+        <dltn:l string="eng">eng</dltn:l>
+        <dltn:l string="deu">german</dltn:l>
+        <dltn:l string="spa">spanish</dltn:l>
+        <dltn:l string="zxx">zxx</dltn:l>
+        <dltn:l string="zxx">no linguistic content.</dltn:l>
     </xsl:param>
 
     <!-- identity tranform -->
@@ -84,6 +85,7 @@
             <xsl:apply-templates select="dc:source[not(contains(., 'Box') or contains(., 'Folder') or contains(., 'Drawer') or starts-with(., 'THS I') or starts-with(., 'XL') or starts-with(., 'VI') or starts-with(., 'RG') or starts-with(., 'IX-A'))]"/>
           <xsl:apply-templates select="dcterms:medium"/>
           <xsl:apply-templates select="dc:type"/>
+          <xsl:apply-templates select="dc:language[1]"/>
         </mods>
     </xsl:template>
     
@@ -188,6 +190,21 @@
     <xsl:template match="dc:type">
         <xsl:for-each select="tokenize(normalize-space(.), ';')">
             <typeOfResource><xsl:value-of select="normalize-space(.)"/></typeOfResource>
+        </xsl:for-each>
+    </xsl:template>
+    
+    <!-- language -->
+    <xsl:template match="dc:language[1]">
+        <xsl:variable name="lang-tokens" select="tokenize(., ';')"/>
+        <xsl:for-each select="$lang-tokens">
+            <xsl:variable name="ltln" select="lower-case(normalize-space(.))"/>
+            <xsl:choose>
+                <xsl:when test="$ltln = $pLang/dltn:l">
+                    <languageTerm type="code" authority="iso639-2b">
+                        <xsl:value-of select="$pLang/dltn:l[. = $ltln]/@string"/>
+                    </languageTerm>
+                </xsl:when>
+            </xsl:choose>
         </xsl:for-each>
     </xsl:template>
 </xsl:stylesheet>

--- a/XSLT/tslaqdctomods.xsl
+++ b/XSLT/tslaqdctomods.xsl
@@ -36,6 +36,17 @@
         <dltn:l string="zxx">zxx</dltn:l>
         <dltn:l string="zxx">no linguistic content.</dltn:l>
     </xsl:param>
+    
+    <xsl:param name="pType">
+        <dltn:type string="still image">Still Image</dltn:type>
+        <dltn:type string="text">Text</dltn:type>
+        <dltn:type string="sound recording">Sound</dltn:type>
+        <dltn:type string="text">Document</dltn:type>
+        <dltn:type string="three dimensional object">Object</dltn:type>
+        <dltn:type string="still image">Still image</dltn:type>
+        <dltn:type string="still image">Image/jp2</dltn:type>
+        <dltn:type string="still image">IMAGE</dltn:type>
+    </xsl:param>
 
     <!-- identity tranform -->
     <xsl:template match="@* | node()">
@@ -189,7 +200,12 @@
     <!-- type -->
     <xsl:template match="dc:type">
         <xsl:for-each select="tokenize(normalize-space(.), ';')">
-            <typeOfResource><xsl:value-of select="normalize-space(.)"/></typeOfResource>
+            <xsl:variable name="current-type" select="normalize-space(.)"/>
+            <xsl:choose>
+                <xsl:when test="$current-type = $pType/dltn:type">
+                    <typeOfResource><xsl:value-of select="$pType/dltn:type[. = $current-type]/@string"/></typeOfResource>
+                </xsl:when>
+            </xsl:choose>
         </xsl:for-each>
     </xsl:template>
     

--- a/XSLT/tslaqdctomods.xsl
+++ b/XSLT/tslaqdctomods.xsl
@@ -200,9 +200,11 @@
             <xsl:variable name="ltln" select="lower-case(normalize-space(.))"/>
             <xsl:choose>
                 <xsl:when test="$ltln = $pLang/dltn:l">
+                    <language>
                     <languageTerm type="code" authority="iso639-2b">
                         <xsl:value-of select="$pLang/dltn:l[. = $ltln]/@string"/>
                     </languageTerm>
+                    </language>
                 </xsl:when>
             </xsl:choose>
         </xsl:for-each>

--- a/XSLT/utcqdctomods.xsl
+++ b/XSLT/utcqdctomods.xsl
@@ -7,6 +7,7 @@
                 xmlns:dcterms="http://purl.org/dc/terms/"
                 xmlns:dc="http://purl.org/dc/elements/1.1/"
                 xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+                xmlns:dltn = "https://github.com/digitallibraryoftennessee"
                 xmlns="http://www.loc.gov/mods/v3"
                 xpath-default-namespace="http://worldcat.org/xmlschema/qdc-1.0/"
                 exclude-result-prefixes="xs xsi oai oai_qdc dcterms dc"
@@ -29,13 +30,13 @@
   -->
   <xsl:variable name="catalog" select="document('catalogs/utc_catalog.xml')"/>
   <xsl:param name="pLang">
-    <l string="eng">english</l>
-    <l string="eng">en</l>
-    <l string="eng">eng</l>
-    <l string="deu">german</l>
-    <l string="spa">spanish</l>
-    <l string="zxx">zxx</l>
-    <l string="zxx">no linguistic content.</l>
+    <dltn:l string="eng">english</dltn:l>
+    <dltn:l string="eng">en</dltn:l>
+    <dltn:l string="eng">eng</dltn:l>
+    <dltn:l string="deu">german</dltn:l>
+    <dltn:l string="spa">spanish</dltn:l>
+    <dltn:l string="zxx">zxx</dltn:l>
+    <dltn:l string="zxx">no linguistic content.</dltn:l>
   </xsl:param>
 
 
@@ -227,9 +228,9 @@
     <xsl:for-each select="$lang-tokens">
       <xsl:variable name="ltln" select="lower-case(normalize-space(.))"/>
       <xsl:choose>
-        <xsl:when test="$ltln = $pLang/l">
+        <xsl:when test="$ltln = $pLang/dltn:l">
           <languageTerm type="code" authority="iso639-2b">
-            <xsl:value-of select="$pLang/l[. = $ltln]/@string"/>
+            <xsl:value-of select="$pLang/dltn:l[. = $ltln]/@string"/>
           </languageTerm>
         </xsl:when>
       </xsl:choose>


### PR DESCRIPTION
* [DLTN_XSLT-120](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/120)
* [DLTN_XSLT-123](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/123)
* [DLTN_XSLT-125](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/125)

## What does this Pull Request do?

This makes the dc:language templates actually work.

## What's new?

The old templates were not working.  This was due to namespace collision.  They should work with this pull request.

## How should this be tested?

For TSLA, take the updated record and run against the updated transform.
For UTC, use whatever sample qdc utc record you want against its updated transform.

## Interested parties

@mlhale7 
