### PR TITLE
Update link to UTC metadata mapping.

### DIFF
--- a/XSLT/utcqdctomods.xsl
+++ b/XSLT/utcqdctomods.xsl
@@ -132,7 +132,7 @@
         <languageOfCataloging>
           <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
         </languageOfCataloging>
-        <recordOrigin>Record has been transformed into MODS 3.5 from a Qualified Dublin Core record by the Digital Library of Tennessee, a service hub of the Digital Public Library of America, using a stylesheet available at https://github.com/digitallibraryoftennessee/DLTN_XSLT. Metadata originally created in a locally modified version of Qualified Dublin Core using ContentDM (data dictionary available: https://wiki.lib.utk.edu/display/DPLA).</recordOrigin>
+        <recordOrigin>Record has been transformed into MODS 3.5 from a Qualified Dublin Core record by the Digital Library of Tennessee, a service hub of the Digital Public Library of America, using a stylesheet available at https://github.com/digitallibraryoftennessee/DLTN_XSLT. Metadata originally created in a locally modified version of Qualified Dublin Core using ContentDM (data dictionary available: https://dltn-technical-docs.readthedocs.io).</recordOrigin>
       </recordInfo>
     </mods>
   </xsl:template>


### PR DESCRIPTION
**GitHub Issue**: [DLTN_XSLT-131](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/131)

* [Mapping](https://dltn-technical-docs.readthedocs.io/en/latest/mappings/utc.html)

## What does this Pull Request do?

Updates the broken link in recordOrigin for UTC.

## What's new?

Just this one line in the main template.

## How should this be tested?

Look at this.  Is it sufficient?  I chose not to directly link to the mapping since it's easy to find from the main page and it's possible the mapping may move within the technical docs.

## Interested parties

@mlhale7 
