### PR TITLE
Add dateIssued values and reorder elements

### DIFF
--- a/Sample_Data/UTK/phoenix.xml
+++ b/Sample_Data/UTK/phoenix.xml
@@ -1,0 +1,11698 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+<responseDate>2019-03-15T14:08:35Z</responseDate>
+<request verb="ListRecords" metadataPrefix="mods" set="phoenix">
+http://dloai.lib.utk.edu/cgi-bin/XMLFile/dlmodsoai/oai.pl
+</request>
+<ListRecords>
+<record>
+<header>
+<identifier>phoenix_652</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1963summer</identifier>
+<identifier type="pid">phoenix:652</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, summer 1963</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1963</dateIssued>
+<dateIssued encoding="edtf">1963-22</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85077519">
+<topic>Literature--History and criticism</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A652
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A652/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2642</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1973spring</identifier>
+<identifier type="pid">phoenix:2642</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1973</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1973</dateIssued>
+<dateIssued encoding="edtf">1973-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2642
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2642/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4902</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1994spring</identifier>
+<identifier type="pid">phoenix:4902</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1994</title>
+</titleInfo>
+<abstract>Black and white issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1994</dateIssued>
+<dateIssued encoding="edtf">1994-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh99002613">
+<topic>Black-and-white photography</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4902
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4902/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4709</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1991fall</identifier>
+<identifier type="pid">phoenix:4709</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1991</title>
+<partNumber>volume 32, issue 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1991</dateIssued>
+<dateIssued encoding="edtf">1991-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n81072740">
+<name>
+<namePart>Thomas, Joyce Carol</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4709
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4709/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5429</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2001spring-dreams</identifier>
+<identifier type="pid">phoenix:5429</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2001, volume 42, issue 1</title>
+</titleInfo>
+<abstract>Dreams and unconsciousness issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2001</dateIssued>
+<dateIssued encoding="edtf">2001-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85039486">
+<topic>Dreams in art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043355">
+<topic>English essays</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5429
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5429/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_476</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1960summer</identifier>
+<identifier type="pid">phoenix:476</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, summer 1960</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1960</dateIssued>
+<dateIssued encoding="edtf">1960-22</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043355">
+<topic>English essays</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A476
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A476/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2421</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1970winter</identifier>
+<identifier type="pid">phoenix:2421</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1970</title>
+</titleInfo>
+<abstract>Revolution - Evolution issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1970</dateIssued>
+<dateIssued encoding="edtf">1970-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043355">
+<topic>English essays</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85088956">
+<topic>Musical criticism</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2421
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2421/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3999</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1984fall</identifier>
+<identifier type="pid">phoenix:3999</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1984</title>
+<partNumber>volume 26, number 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1984</dateIssued>
+<dateIssued encoding="edtf">1984-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3999
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3999/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_597</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1962summer</identifier>
+<identifier type="pid">phoenix:597</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, summer 1962</title>
+<partNumber>volume 3, number 3</partNumber>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1962</dateIssued>
+<dateIssued encoding="edtf">1962-22</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85077519">
+<topic>Literature--History and criticism</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A597
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A597/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4110</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1985fall</identifier>
+<identifier type="pid">phoenix:4110</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1985</title>
+<partNumber>volume 27, number 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1985</dateIssued>
+<dateIssued encoding="edtf">1985-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4110
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4110/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2111</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1967fall</identifier>
+<identifier type="pid">phoenix:2111</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1967</title>
+<partNumber>volume 9, number 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1967</dateIssued>
+<dateIssued encoding="edtf">1967-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2111
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2111/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5066</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1997fall</identifier>
+<identifier type="pid">phoenix:5066</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1997</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1997</dateIssued>
+<dateIssued encoding="edtf">1997-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5066
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5066/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2361</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1970fall</identifier>
+<identifier type="pid">phoenix:2361</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1970</title>
+<partNumber>volume 12, number 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1970</dateIssued>
+<dateIssued encoding="edtf">1970-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2361
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2361/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_6277</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2013spring</identifier>
+<identifier type="pid">phoenix:6277</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2013</title>
+<partNumber>volume 54, issue 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2013</dateIssued>
+<dateIssued encoding="edtf">2013-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6277
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6277/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_689</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1964fall</identifier>
+<identifier type="pid">phoenix:689</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1964</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1964</dateIssued>
+<dateIssued encoding="edtf">1964-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A689
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A689/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4324</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1987spring</identifier>
+<identifier type="pid">phoenix:4324</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1987</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1987</dateIssued>
+<dateIssued encoding="edtf">1987-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4324
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4324/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_510</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1961spring</identifier>
+<identifier type="pid">phoenix:510</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1961</title>
+</titleInfo>
+<abstract>Poetry issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1961</dateIssued>
+<dateIssued encoding="edtf">1961-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A510
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A510/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5887</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2009spring</identifier>
+<identifier type="pid">phoenix:5887</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2009</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2009</dateIssued>
+<dateIssued encoding="edtf">2009-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5887
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5887/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3851</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1982winter</identifier>
+<identifier type="pid">phoenix:3851</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1982</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1982</dateIssued>
+<dateIssued encoding="edtf">1982-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3851
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3851/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3777</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1982fall</identifier>
+<identifier type="pid">phoenix:3777</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1982</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1982</dateIssued>
+<dateIssued encoding="edtf">1982-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh99002613">
+<topic>Black-and-white photography</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3777
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3777/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_438</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1960fall</identifier>
+<identifier type="pid">phoenix:438</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1960</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1960</dateIssued>
+<dateIssued encoding="edtf">1960-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85015752">
+<topic>Books--Reviews</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A438
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A438/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_672</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1963winter</identifier>
+<identifier type="pid">phoenix:672</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1963</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1963</dateIssued>
+<dateIssued encoding="edtf">1963-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n50015825">
+<name>
+<namePart>Sanders, Norman (Norman J.)</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A672
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A672/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5323</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1999spring</identifier>
+<identifier type="pid">phoenix:5323</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1999</title>
+</titleInfo>
+<abstract>Fear and power issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1999</dateIssued>
+<dateIssued encoding="edtf">1999-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5323
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5323/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2186</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1967spring</identifier>
+<identifier type="pid">phoenix:2186</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1967</title>
+<partNumber>volume 8, number 5</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1967</dateIssued>
+<dateIssued encoding="edtf">1967-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004407">
+<topic>American prose literature</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2186
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2186/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5505</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2002spring</identifier>
+<identifier type="pid">phoenix:5505</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2002</title>
+<partNumber>volume 43, issue 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2002</dateIssued>
+<dateIssued encoding="edtf">2002-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5505
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5505/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2386</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1970spring</identifier>
+<identifier type="pid">phoenix:2386</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1970</title>
+<partNumber>volume 11, number 3</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1970</dateIssued>
+<dateIssued encoding="edtf">1970-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2386
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2386/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2732</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1974fall</identifier>
+<identifier type="pid">phoenix:2732</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1974</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1974</dateIssued>
+<dateIssued encoding="edtf">1974-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n79062804">
+<name>
+<namePart>Wolfe, Tom</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2732
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2732/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5364</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2001spring</identifier>
+<identifier type="pid">phoenix:5364</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2001, volume 42, issue 2</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2001</dateIssued>
+<dateIssued encoding="edtf">2001-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004407">
+<topic>American prose literature</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5364
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5364/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5713</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2006fall</identifier>
+<identifier type="pid">phoenix:5713</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 2006</title>
+<partNumber>volume 48, issue 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2006</dateIssued>
+<dateIssued encoding="edtf">2006-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5713
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5713/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2479</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1971spring</identifier>
+<identifier type="pid">phoenix:2479</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1971</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1971</dateIssued>
+<dateIssued encoding="edtf">1971-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2479
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2479/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_6232</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2012spring</identifier>
+<identifier type="pid">phoenix:6232</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2012</title>
+<partNumber>volume 53, number 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2012</dateIssued>
+<dateIssued encoding="edtf">2012-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6232
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6232/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3666</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1980winter</identifier>
+<identifier type="pid">phoenix:3666</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1980</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1980</dateIssued>
+<dateIssued encoding="edtf">1980-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3666
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3666/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4467</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1988fall</identifier>
+<identifier type="pid">phoenix:4467</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1988</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1988</dateIssued>
+<dateIssued encoding="edtf">1988-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4467
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4467/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2161</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1967policecover</identifier>
+<identifier type="pid">phoenix:2161</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, 1967</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1967</dateIssued>
+<dateIssued encoding="edtf">1967</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2161
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2161/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4955</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1995fall</identifier>
+<identifier type="pid">phoenix:4955</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1995</title>
+</titleInfo>
+<abstract>The Elvis issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1995</dateIssued>
+<dateIssued encoding="edtf">1995-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n78079487">
+<name>
+<namePart>Presley, Elvis, 1935-1977</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4955
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4955/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2922</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1975winter</identifier>
+<identifier type="pid">phoenix:2922</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1975</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1975</dateIssued>
+<dateIssued encoding="edtf">1975-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85033849">
+<topic>Creative writing (Higher education)</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2922
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2922/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2565</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1972spring</identifier>
+<identifier type="pid">phoenix:2565</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1972</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1972</dateIssued>
+<dateIssued encoding="edtf">1972-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh99002613">
+<topic>Black-and-white photography</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2565
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2565/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4073</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1984winter</identifier>
+<identifier type="pid">phoenix:4073</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1984</title>
+<partNumber>volume 25, number 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1984</dateIssued>
+<dateIssued encoding="edtf">1984-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4073
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4073/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2695</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1973winter</identifier>
+<identifier type="pid">phoenix:2695</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1973</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1973</dateIssued>
+<dateIssued encoding="edtf">1973-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2695
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2695/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3444</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1979fall</identifier>
+<identifier type="pid">phoenix:3444</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1979</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1979</dateIssued>
+<dateIssued encoding="edtf">1979-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n80066908">
+<name>
+<namePart>Sturgeon, Theodore</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3444
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3444/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3407</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1979winter</identifier>
+<identifier type="pid">phoenix:3407</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1979</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1979</dateIssued>
+<dateIssued encoding="edtf">1979-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n96014442">
+<name>
+<namePart>Hunley, Con</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3407
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3407/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2766</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1974spring</identifier>
+<identifier type="pid">phoenix:2766</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1974</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1974</dateIssued>
+<dateIssued encoding="edtf">1974-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85029403">
+<topic>Composition (Music)</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n79065951">
+<name>
+<namePart>Marceau, Marcel</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2766
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2766/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4861</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1993fall</identifier>
+<identifier type="pid">phoenix:4861</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1993</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1993</dateIssued>
+<dateIssued encoding="edtf">1993-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4861
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4861/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2311</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1968winter</identifier>
+<identifier type="pid">phoenix:2311</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1968</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1968</dateIssued>
+<dateIssued encoding="edtf">1968-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2311
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2311/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2332</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1969fall</identifier>
+<identifier type="pid">phoenix:2332</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1969</title>
+<partNumber>volume 11, number 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1969</dateIssued>
+<dateIssued encoding="edtf">1969-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2332
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2332/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2236</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1968fall</identifier>
+<identifier type="pid">phoenix:2236</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1968</title>
+<partNumber>volume 10, number 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1968</dateIssued>
+<dateIssued encoding="edtf">1968-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2236
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2236/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5025</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1996fall</identifier>
+<identifier type="pid">phoenix:5025</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1996</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1996</dateIssued>
+<dateIssued encoding="edtf">1996-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85121819">
+<topic>Short stories, American</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5025
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5025/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3592</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1981spring</identifier>
+<identifier type="pid">phoenix:3592</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1981</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1981</dateIssued>
+<dateIssued encoding="edtf">1981-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh99002613">
+<topic>Black-and-white photography</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n81062666">
+<name>
+<namePart>Huxtable, Ada Louise</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3592
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3592/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2086</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1966fall</identifier>
+<identifier type="pid">phoenix:2086</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1966</title>
+</titleInfo>
+<abstract>Harvard Lampoon parody issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1966</dateIssued>
+<dateIssued encoding="edtf">1966-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2086
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2086/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5581</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2004fall</identifier>
+<identifier type="pid">phoenix:5581</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 2004</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2004</dateIssued>
+<dateIssued encoding="edtf">2004-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004407">
+<topic>American prose literature</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5581
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5581/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_6105</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2011spring</identifier>
+<identifier type="pid">phoenix:6105</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2011</title>
+<partNumber>volume 52, number 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2011</dateIssued>
+<dateIssued encoding="edtf">2011-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004407">
+<topic>American prose literature</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85029403">
+<topic>Composition (Music)</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6105
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6105/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4258</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1986spring</identifier>
+<identifier type="pid">phoenix:4258</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1986</title>
+<partNumber>volume 27, number 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1986</dateIssued>
+<dateIssued encoding="edtf">1986-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4258
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4258/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4295</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1987fall</identifier>
+<identifier type="pid">phoenix:4295</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1987</title>
+<partNumber>volume 29, number 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1987</dateIssued>
+<dateIssued encoding="edtf">1987-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4295
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4295/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5988</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2010spring</identifier>
+<identifier type="pid">phoenix:5988</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2010</title>
+<partNumber>volume 51, number 2</partNumber>
+</titleInfo>
+<abstract>50th anniversary issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2010</dateIssued>
+<dateIssued encoding="edtf">2010-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114835">
+<topic>American poetry--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079579">
+<topic>Magazine illustration</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079577">
+<topic>Magazine covers</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5988
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5988/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4980</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1995spring</identifier>
+<identifier type="pid">phoenix:4980</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1995</title>
+</titleInfo>
+<abstract>Mandatory information issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1995</dateIssued>
+<dateIssued encoding="edtf">1995-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4980
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4980/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_580</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1962spring</identifier>
+<identifier type="pid">phoenix:580</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1962</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1962</dateIssued>
+<dateIssued encoding="edtf">1962-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A580
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A580/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3000</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1976spring</identifier>
+<identifier type="pid">phoenix:3000</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1976</title>
+</titleInfo>
+<abstract>Art and the individual issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1976</dateIssued>
+<dateIssued encoding="edtf">1976-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n83051428">
+<name>
+<namePart>Adcock, Betty</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3000
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3000/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2586</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1972winter</identifier>
+<identifier type="pid">phoenix:2586</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1972</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1972</dateIssued>
+<dateIssued encoding="edtf">1972-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2586
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2586/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5750</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2006spring</identifier>
+<identifier type="pid">phoenix:5750</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2006</title>
+</titleInfo>
+<abstract>Music issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2006</dateIssued>
+<dateIssued encoding="edtf">2006-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88003553">
+<topic>Musicians--United States</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n79109786">
+<geographic>Knoxville (Tenn.)</geographic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/no2013043949">
+<name>
+<namePart>Capps, Ashley</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5750
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5750/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4353</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1987winter</identifier>
+<identifier type="pid">phoenix:4353</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1987</title>
+<partNumber>volume 29, number 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1987</dateIssued>
+<dateIssued encoding="edtf">1987-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4353
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4353/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5468</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2002fall</identifier>
+<identifier type="pid">phoenix:5468</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 2002</title>
+<partNumber>volume 44, issue 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2002</dateIssued>
+<dateIssued encoding="edtf">2002-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5468
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5468/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2065</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1965winter</identifier>
+<identifier type="pid">phoenix:2065</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1965</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1965</dateIssued>
+<dateIssued encoding="edtf">1965-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85077519">
+<topic>Literature--History and criticism</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2065
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2065/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3703</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1978winter</identifier>
+<identifier type="pid">phoenix:3703</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1978</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1978</dateIssued>
+<dateIssued encoding="edtf">1978-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n50020228">
+<name>
+<namePart>White, Jon Manchip, 1924-2013</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3703
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3703/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5267</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1998springfiction</identifier>
+<identifier type="pid">phoenix:5267</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1998 (fiction edition)</title>
+</titleInfo>
+<abstract>Fiction edition.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1998</dateIssued>
+<dateIssued encoding="edtf">1998-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5267
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5267/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4229</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1986fall</identifier>
+<identifier type="pid">phoenix:4229</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1986</title>
+<partNumber>volume 27, number 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1986</dateIssued>
+<dateIssued encoding="edtf">1986-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004424">
+<topic>American wit and humor</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4229
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4229/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3333</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1977fall</identifier>
+<identifier type="pid">phoenix:3333</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1977</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1977</dateIssued>
+<dateIssued encoding="edtf">1977-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh99002613">
+<topic>Black-and-white photography</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3333
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3333/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2454</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1971fall</identifier>
+<identifier type="pid">phoenix:2454</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1971</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1971</dateIssued>
+<dateIssued encoding="edtf">1971-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2454
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2454/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5193</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1998fall</identifier>
+<identifier type="pid">phoenix:5193</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1998</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1998</dateIssued>
+<dateIssued encoding="edtf">1998-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5193
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5193/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4623</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1990fall</identifier>
+<identifier type="pid">phoenix:4623</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1990</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1990</dateIssued>
+<dateIssued encoding="edtf">1990-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4623
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4623/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_6351</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2000march</identifier>
+<identifier type="pid">phoenix:6351</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, March 2000</title>
+</titleInfo>
+<abstract>40th anniversary issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2000</dateIssued>
+<dateIssued encoding="edtf">2000-03</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114835">
+<topic>American poetry--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079579">
+<topic>Magazine illustration</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079577">
+<topic>Magazine covers</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6351
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6351/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5103</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1997fall-photo</identifier>
+<identifier type="pid">phoenix:5103</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1997, volume 38, issue 2</title>
+</titleInfo>
+<abstract>Black and white photography issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1997</dateIssued>
+<dateIssued encoding="edtf">1997-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh99002613">
+<topic>Black-and-white photography</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n79109786">
+<geographic>Knoxville (Tenn.)</geographic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5103
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5103/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5852</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2009fall</identifier>
+<identifier type="pid">phoenix:5852</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 2009</title>
+<partNumber>volume 51, issue 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2009</dateIssued>
+<dateIssued encoding="edtf">2009-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5852
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5852/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3518</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1977spring</identifier>
+<identifier type="pid">phoenix:3518</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1977</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1977</dateIssued>
+<dateIssued encoding="edtf">1977-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3518
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3518/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_455</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1960spring</identifier>
+<identifier type="pid">phoenix:455</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1960</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<name authority="naf" valueURI="http://id.loc.gov/authorities/names/n82028392">
+<namePart>McCarthy, Cormac, 1933-</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/aut">Author</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1960</dateIssued>
+<dateIssued encoding="edtf">1960-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004407">
+<topic>American prose literature</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A455
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A455/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2032</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1965fall</identifier>
+<identifier type="pid">phoenix:2032</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1965</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1965</dateIssued>
+<dateIssued encoding="edtf">1965-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043355">
+<topic>English essays</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2032
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2032/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4582</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1989spring</identifier>
+<identifier type="pid">phoenix:4582</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1989</title>
+<partNumber>volume 30, issue 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1989</dateIssued>
+<dateIssued encoding="edtf">1989-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043355">
+<topic>English essays</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4582
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4582/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5951</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2010fall</identifier>
+<identifier type="pid">phoenix:5951</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 2010</title>
+<partNumber>volume 52, issue 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2010</dateIssued>
+<dateIssued encoding="edtf">2010-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5951
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5951/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_6158</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2012fall</identifier>
+<identifier type="pid">phoenix:6158</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 2012</title>
+<partNumber>volume 54, issue 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2012</dateIssued>
+<dateIssued encoding="edtf">2012-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6158
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6158/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3481</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1978spring</identifier>
+<identifier type="pid">phoenix:3481</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1978</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1978</dateIssued>
+<dateIssued encoding="edtf">1978-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n79110568">
+<name>
+<namePart>Dykeman, Wilma</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3481
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3481/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4036</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1984spring</identifier>
+<identifier type="pid">phoenix:4036</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1984</title>
+<partNumber>volume 25, number 3</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1984</dateIssued>
+<dateIssued encoding="edtf">1984-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004424">
+<topic>American wit and humor</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4036
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4036/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2265</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1968spring</identifier>
+<identifier type="pid">phoenix:2265</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1968</title>
+<partNumber>volume 9, number 3</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1968</dateIssued>
+<dateIssued encoding="edtf">1968-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2265
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2265/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3740</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1977winter</identifier>
+<identifier type="pid">phoenix:3740</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1977</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1977</dateIssued>
+<dateIssued encoding="edtf">1977-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85077519">
+<topic>Literature--History and criticism</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n89607131">
+<name>
+<namePart>Dumas, Bethany K.</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3740
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3740/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_563</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1962fall</identifier>
+<identifier type="pid">phoenix:563</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1962</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1962</dateIssued>
+<dateIssued encoding="edtf">1962-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043833">
+<topic>English literature--History and criticism</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A563
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A563/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2533</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1972fall</identifier>
+<identifier type="pid">phoenix:2533</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1972</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1972</dateIssued>
+<dateIssued encoding="edtf">1972-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2533
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2533/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2799</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1974spring-supplement</identifier>
+<identifier type="pid">phoenix:2799</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>
+Poetry workshop: supplement to the Phoenix, spring 1974
+</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1974</dateIssued>
+<dateIssued encoding="edtf">1974-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2799
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2799/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4410</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1987winter-supplement</identifier>
+<identifier type="pid">phoenix:4410</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1987 (supplement)</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1987</dateIssued>
+<dateIssued encoding="edtf">1987-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh99002613">
+<topic>Black-and-white photography</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4410
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4410/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2812</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1974winter</identifier>
+<identifier type="pid">phoenix:2812</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1974</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1974</dateIssued>
+<dateIssued encoding="edtf">1974-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043355">
+<topic>English essays</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2812
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2812/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4529</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1989fall</identifier>
+<identifier type="pid">phoenix:4529</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1989</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1989</dateIssued>
+<dateIssued encoding="edtf">1989-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4529
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4529/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4500</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1988spring</identifier>
+<identifier type="pid">phoenix:4500</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1988</title>
+<partNumber>volume 29, number 3</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1988</dateIssued>
+<dateIssued encoding="edtf">1988-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4500
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4500/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2211</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1967winter</identifier>
+<identifier type="pid">phoenix:2211</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1967</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1967</dateIssued>
+<dateIssued encoding="edtf">1967-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85077519">
+<topic>Literature--History and criticism</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2211
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2211/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_493</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1960winter</identifier>
+<identifier type="pid">phoenix:493</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1960</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1960</dateIssued>
+<dateIssued encoding="edtf">1960-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85077519">
+<topic>Literature--History and criticism</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A493
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A493/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3962</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1983winter</identifier>
+<identifier type="pid">phoenix:3962</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1983</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1983</dateIssued>
+<dateIssued encoding="edtf">1983-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n50024879">
+<name>
+<namePart>Angelou, Maya</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3962
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3962/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3629</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1981fall</identifier>
+<identifier type="pid">phoenix:3629</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1981</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1981</dateIssued>
+<dateIssued encoding="edtf">1981-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004407">
+<topic>American prose literature</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh99002613">
+<topic>Black-and-white photography</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3629
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3629/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5672</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2005spring</identifier>
+<identifier type="pid">phoenix:5672</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2005</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2005</dateIssued>
+<dateIssued encoding="edtf">2005-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043355">
+<topic>English essays</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh93004752">
+<topic>Environmentalism</topic>
+</subject>
+<subject>
+<name>
+<namePart>Yee-Haw Industries</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5672
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5672/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3888</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1983fall</identifier>
+<identifier type="pid">phoenix:3888</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1983</title>
+<partNumber>volume 25, number 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1983</dateIssued>
+<dateIssued encoding="edtf">1983-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3888
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3888/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5230</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1998springcultural</identifier>
+<identifier type="pid">phoenix:5230</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1998 (Cultural exploration issue)</title>
+</titleInfo>
+<abstract>Cultural exploration issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1998</dateIssued>
+<dateIssued encoding="edtf">1998-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2004005109">
+<topic>Culture in art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5230
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5230/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_527</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1961summer</identifier>
+<identifier type="pid">phoenix:527</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, summer 1961</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1961</dateIssued>
+<dateIssued encoding="edtf">1961-22</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85077519">
+<topic>Literature--History and criticism</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A527
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A527/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3555</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1981winter</identifier>
+<identifier type="pid">phoenix:3555</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1981</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1981</dateIssued>
+<dateIssued encoding="edtf">1981-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3555
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3555/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5651</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2005fall</identifier>
+<identifier type="pid">phoenix:5651</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 2005</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2005</dateIssued>
+<dateIssued encoding="edtf">2005-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5651
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5651/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_6195</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2013fall</identifier>
+<identifier type="pid">phoenix:6195</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 2013</title>
+<partNumber>volume 55, issue 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2013</dateIssued>
+<dateIssued encoding="edtf">2013-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh93002335">
+<topic>Photocollage</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6195
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6195/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2286</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1968summer</identifier>
+<identifier type="pid">phoenix:2286</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, summer 1968</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1968</dateIssued>
+<dateIssued encoding="edtf">1968-22</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n50031284">
+<name>
+<namePart>Hoffer, Eric</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2286
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2286/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5791</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2008fall</identifier>
+<identifier type="pid">phoenix:5791</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 2008</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2008</dateIssued>
+<dateIssued encoding="edtf">2008-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n79117271">
+<name>
+<namePart>Kallet, Marilyn, 1946-</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5791
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5791/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_542</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1961winter</identifier>
+<identifier type="pid">phoenix:542</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1961</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1961</dateIssued>
+<dateIssued encoding="edtf">1961-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85077519">
+<topic>Literature--History and criticism</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A542
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A542/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2881</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1975spring</identifier>
+<identifier type="pid">phoenix:2881</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1975</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1975</dateIssued>
+<dateIssued encoding="edtf">1975-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2881
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2881/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4155</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1985spring</identifier>
+<identifier type="pid">phoenix:4155</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1985</title>
+<partNumber>volume 26, number 3</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1985</dateIssued>
+<dateIssued encoding="edtf">1985-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4155
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4155/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_6314</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2000spring</identifier>
+<identifier type="pid">phoenix:6314</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2000</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2000</dateIssued>
+<dateIssued encoding="edtf">2000-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6314
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6314/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_421</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1959fall</identifier>
+<identifier type="pid">phoenix:421</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1959</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<name authority="naf" valueURI="http://id.loc.gov/authorities/names/n82028392">
+<namePart>McCarthy, Cormac, 1933-</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/aut">Author</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1959</dateIssued>
+<dateIssued encoding="edtf">1959-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A421
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A421/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2845</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1975fall</identifier>
+<identifier type="pid">phoenix:2845</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1975</title>
+</titleInfo>
+<abstract>Performing arts issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1975</dateIssued>
+<dateIssued encoding="edtf">1975-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n86079455">
+<name>
+<namePart>
+Highlander Research and Education Center (Knoxville, Tenn.)
+</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2845
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2845/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5164</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1997spring</identifier>
+<identifier type="pid">phoenix:5164</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1997</title>
+<partNumber>volume 38, number 3</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1997</dateIssued>
+<dateIssued encoding="edtf">1997-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5164
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5164/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4787</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1992fall</identifier>
+<identifier type="pid">phoenix:4787</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1992</title>
+<partNumber>volume 34, issue 1</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1992</dateIssued>
+<dateIssued encoding="edtf">1992-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4787
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4787/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_710</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1964spring</identifier>
+<identifier type="pid">phoenix:710</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1964</title>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1964</dateIssued>
+<dateIssued encoding="edtf">1964-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85077519">
+<topic>Literature--History and criticism</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A710
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A710/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_631</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1963fall</identifier>
+<identifier type="pid">phoenix:631</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1963</title>
+<partNumber>volume 5, number 1</partNumber>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1963</dateIssued>
+<dateIssued encoding="edtf">1963-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A631
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A631/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5540</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2003spring</identifier>
+<identifier type="pid">phoenix:5540</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2003</title>
+</titleInfo>
+<abstract>Hollywood issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2003</dateIssued>
+<dateIssued encoding="edtf">2003-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004407">
+<topic>American prose literature</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5540
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5540/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_614</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1962winter</identifier>
+<identifier type="pid">phoenix:614</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1962</title>
+<partNumber>volume 3, number 1</partNumber>
+</titleInfo>
+<abstract>Orange and white literary supplement.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1962</dateIssued>
+<dateIssued encoding="edtf">1962-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85077519">
+<topic>Literature--History and criticism</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A614
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A614/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3370</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1976winter</identifier>
+<identifier type="pid">phoenix:3370</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1976</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1976</dateIssued>
+<dateIssued encoding="edtf">1976-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3370
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3370/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3925</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1983spring</identifier>
+<identifier type="pid">phoenix:3925</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1983</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1983</dateIssued>
+<dateIssued encoding="edtf">1983-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3925
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3925/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2963</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1976fall</identifier>
+<identifier type="pid">phoenix:2963</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1976</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1976</dateIssued>
+<dateIssued encoding="edtf">1976-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="ttp://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh99002613">
+<topic>Black-and-white photography</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2963
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2963/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_3814</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1982spring</identifier>
+<identifier type="pid">phoenix:3814</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1982</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1982</dateIssued>
+<dateIssued encoding="edtf">1982-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh99002613">
+<topic>Black-and-white photography</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3814
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A3814/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4192</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1985winter</identifier>
+<identifier type="pid">phoenix:4192</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1985</title>
+<partNumber>volume 26, number 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1985</dateIssued>
+<dateIssued encoding="edtf">1985-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85067568">
+<topic>Interviews</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004424">
+<topic>American wit and humor</topic>
+</subject>
+<subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n84191741">
+<name>
+<namePart>Heffernan, Thomas J., 1944-</namePart>
+</name>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4192
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4192/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2607</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1973fall</identifier>
+<identifier type="pid">phoenix:2607</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1973</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1973</dateIssued>
+<dateIssued encoding="edtf">1973-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85047539">
+<topic>Feature writing</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2607
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2607/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2508</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1971winter</identifier>
+<identifier type="pid">phoenix:2508</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, winter 1971</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1971</dateIssued>
+<dateIssued encoding="edtf">1971-24</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043355">
+<topic>English essays</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2508
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2508/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_2136</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1967march</identifier>
+<identifier type="pid">phoenix:2136</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, March 1967</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003887">
+<namePart>University of Tennessee (Knoxville campus)</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1967</dateIssued>
+<dateIssued encoding="edtf">1967-03</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2136
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A2136/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_6428</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2000fall</identifier>
+<identifier type="pid">phoenix:6428</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 2000</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2000</dateIssued>
+<dateIssued encoding="edtf">2000-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004317">
+<topic>American fiction</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85033827">
+<topic>Creation (Literary, artistic, etc.)</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6428
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A6428/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4664</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1990spring</identifier>
+<identifier type="pid">phoenix:4664</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1990</title>
+<partNumber>volume 31, issue 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1990</dateIssued>
+<dateIssued encoding="edtf">1990-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4664
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4664/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4824</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1992spring</identifier>
+<identifier type="pid">phoenix:4824</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1992</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1992</dateIssued>
+<dateIssued encoding="edtf">1992-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043355">
+<topic>English essays</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4824
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4824/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5614</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_2004spring</identifier>
+<identifier type="pid">phoenix:5614</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 2004</title>
+<partNumber>volume 45, number 1</partNumber>
+</titleInfo>
+<abstract>Inspiration issue.</abstract>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>2004</dateIssued>
+<dateIssued encoding="edtf">2004-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101067">
+<topic>American poetry--21st century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2006004388">
+<topic>Magazine illustration--21st century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009008117">
+<topic>Creative nonfiction</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5614
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5614/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_5286</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1999fall</identifier>
+<identifier type="pid">phoenix:5286</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, fall 1999</title>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1999</dateIssued>
+<dateIssued encoding="edtf">1999-23</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85004407">
+<topic>American prose literature</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5286
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A5286/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+<record>
+<header>
+<identifier>phoenix_4750</identifier>
+<datestamp>2019-03-15T02:00:34Z</datestamp>
+<setSpec>phoenix</setSpec>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<identifier type="local">phoenix_1991spring</identifier>
+<identifier type="pid">phoenix:4750</identifier>
+<identifier type="issn">2641-4562</identifier>
+<titleInfo supplied="yes">
+<title>Phoenix, spring 1991</title>
+<partNumber>volume 32, issue 2</partNumber>
+</titleInfo>
+<abstract>
+Phoenix is a student-led literary publication, showcasing the creative output of UT's diverse student population, including photography, illustration, poetry, fiction, non-fiction, and interviews.
+</abstract>
+<name authority="naf" type="corporate" valueURI="http://id.loc.gov/authorities/names/n80003889">
+<namePart>University of Tennessee, Knoxville</namePart>
+<role>
+<roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+</role>
+</name>
+<physicalDescription>
+<form authority="aat" valueURI="http://vocab.getty.edu/aat/300215389">magazines (periodicals)</form>
+</physicalDescription>
+<originInfo>
+<dateIssued>1991</dateIssued>
+<dateIssued encoding="edtf">1991-21</dateIssued>
+<place>
+<placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+</place>
+</originInfo>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85028351">
+<topic>College student newspapers and periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh88002030">
+<topic>College students' writings</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008005687">
+<topic>College students' art</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2007101066">
+<topic>American poetry--20th century--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85079581">
+<topic>Magazine illustration--20th century</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2008109275">
+<topic>Photography, Artistic--Periodicals</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85043355">
+<topic>English essays</topic>
+</subject>
+<subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh2009114780">
+<topic>American fiction--20th century--Periodicals</topic>
+</subject>
+<typeOfResource>text</typeOfResource>
+<typeOfResource>still image</typeOfResource>
+<relatedItem displayLabel="Project" type="host">
+<titleInfo>
+<title>Phoenix</title>
+</titleInfo>
+</relatedItem>
+<location>
+<physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+University of Tennessee, Knoxville. Special Collections
+</physicalLocation>
+<url access="object in context" usage="primary display">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4750
+</url>
+<url access="preview">
+https://digital.lib.utk.edu/collections/islandora/object/phoenix%3A4750/datastream/TN/view
+</url>
+</location>
+<classification authority="lcc">LH1.T2 P3</classification>
+<language>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</language>
+<recordInfo>
+<recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+<languageOfCataloging>
+<languageTerm authority="iso639-2b" type="text">English</languageTerm>
+</languageOfCataloging>
+<recordOrigin>
+Created and edited in general conformance to MODS Guidelines (Version 3.5).
+</recordOrigin>
+</recordInfo>
+<accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>
+</metadata>
+</record>
+</ListRecords>
+</OAI-PMH>

--- a/XSLT/utkMODStoMODS.xsl
+++ b/XSLT/utkMODStoMODS.xsl
@@ -1,5 +1,6 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
     xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:mods="http://www.loc.gov/mods/v3"
+    xmlns="http://www.loc.gov/mods/v3"
     version="2.0" exclude-result-prefixes="mods">
     <xsl:output omit-xml-declaration="yes" method="xml" encoding="UTF-8" indent="yes"/>
     
@@ -12,28 +13,27 @@
             xmlns:xlink="http://www.w3.org/1999/xlink"
             xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+            <xsl:apply-templates select="mods:identifier"/>
             <xsl:apply-templates select="mods:titleInfo"/>
-            <xsl:apply-templates select="mods:typeOfResource"/>
-            <xsl:apply-templates select="mods:genre"/> <!-- copied over as found, also copied below for use as genre -->
-            <xsl:apply-templates select="mods:originInfo"/>
-            <xsl:apply-templates select="mods:language"/>
-            <xsl:apply-templates select="mods:physicalDescription"/>
             <xsl:apply-templates select="mods:abstract"/>
+            <xsl:apply-templates select="mods:name"/> <!-- not handing over unknowns to DLTN, though we do keep in UTK Islandora -->
+            <xsl:apply-templates select="mods:originInfo"/>
+            <xsl:apply-templates select="mods:physicalDescription"/>
             <xsl:apply-templates select="mods:note"/>
             <xsl:apply-templates select="mods:subject"/>
-            <xsl:apply-templates select="mods:relatedItem"/>
-            <xsl:apply-templates select="mods:identifier"/>
-            <xsl:apply-templates select="mods:accessCondition"/>
-            <xsl:apply-templates select="mods:part"/>
-            <xsl:apply-templates select="mods:recordInfo"/>
-            
-            <xsl:apply-templates select="mods:name"/> <!-- not handing over unknowns to DLTN, though we do keep in UTK Islandora -->
             <xsl:apply-templates select="mods:physicalDescription/mods:form" mode="form2genre"/> <!-- DPLA genre is UTK form - UTK form being copied over -->
+            <xsl:apply-templates select="mods:genre"/> <!-- copied over as found, also copied below for use as genre -->
+            <xsl:apply-templates select="mods:language"/>
+            <xsl:apply-templates select="mods:typeOfResource"/>
+            <xsl:apply-templates select="mods:relatedItem"/>
+            <xsl:apply-templates select="mods:part"/>
             <location>
                 <xsl:apply-templates select="mods:location/mods:physicalLocation"/>
                 <xsl:apply-templates select="mods:location/mods:url"/>
                 <xsl:apply-templates select="mods:location/mods:holdingExternal"/>
             </location>
+            <xsl:apply-templates select="mods:recordInfo"/>
+            <xsl:apply-templates select="mods:accessCondition"/>
         </mods>
     </xsl:template>
     
@@ -57,7 +57,18 @@
     </xsl:template>
 
     <xsl:template match="mods:originInfo">
-        <xsl:copy copy-namespaces="no"><xsl:copy-of select="mods:dateCreated[@encoding='edtf']" copy-namespaces="no"></xsl:copy-of></xsl:copy>
+        <xsl:copy copy-namespaces="no">
+            <xsl:choose>
+                <xsl:when test="mods:dateIssued[@encoding='edtf']">
+                    <dateCreated>
+                        <xsl:value-of select="mods:dateIssued[@encoding='edtf']"/>
+                    </dateCreated>
+                </xsl:when>
+                <xsl:when test="mods:dateCreated">
+                    <xsl:copy-of select="mods:dateCreated" copy-namespaces="no"/>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:copy>
     </xsl:template>
     
     <xsl:template match="mods:physicalDescription/mods:form" mode="form2genre"> <!-- DPLA genre is UTK form - UTK form being copied over -->


### PR DESCRIPTION
**Jira Issue**: [DPLA-233](https://jirautk.atlassian.net/browse/DPLA-233)

* Other Relevant Links - [Order of XML Elements](https://dltn-technical-docs.readthedocs.io/en/latest/style/xsl.html)

## What does this Pull Request do?

This pull requests includes dateIssued in the transformation and places these values in dateCreated[@edtf] tags in the resulting metadata (lines 59-72). A sample file from Phoenix that has a dateIssued tag has also been included for testing. Because many of the student publications that were recently remediated have a dateIssued rather than a dateCreated tag, making these changes allows the metadata being shared with DPLA to be more complete.

Because changes were already being made, I also updated the order of the elements within the XSLT so that they follow the new order established on DLTN Technical Docs (link above).

## How should this be tested?

To test:

* Run the transform against the sample data (phoenix.xml)
* Run the transform against another UTK set of data that includes dateCreated values
* See if any blank or empty nodes are created.
* Check to see if the elements follow the ordering in https://dltn-technical-docs.readthedocs.io/en/latest/style/xsl.html

## Additional Notes:

I'm uncertain what level of edtf DPLA can handle. Phoenix has seasons included in the metadata that may or may not be helpful. If felt to be better, we could take the non-edtf dateIssued value but this would change things so that we have two different resulting dateCreated tags instead of the one dateCreated with encoding.

I'm hoping to get this set for the March 18th DPLA ingest. If we can get things ready, I will go ahead and reingest sets in Repox that will be affected by the dateIssued change. All sets can be reharvested if we'd like to get the new XML order in place.

## Interested parties

@markpbaggett @CanOfBees 
