### PR TITLE
Address DLTN_XSLT-152.

### DIFF
--- a/XSLT/rhodes_dspace_xoai_to_mods_farnsworth.xsl
+++ b/XSLT/rhodes_dspace_xoai_to_mods_farnsworth.xsl
@@ -155,7 +155,16 @@
     
     <!-- Thumbnail -->
     <xsl:template match='element[@name="bundles"]/element[@name="bundle"][field[@name="name"][text()="THUMBNAIL"]]/element[@name="bitstreams"]/element[@name="bitstream"][1]/field[@name="url"]'>
-            <url access="preview"><xsl:apply-templates/></url>
+        <xsl:variable name="thumbnail-link" select="./text()"/>
+        <xsl:choose>
+            <xsl:when test="starts-with($thumbnail-link, 'http://dam-2013.rhodes.edu:8080/xmlui')">
+                <xsl:variable name="new-thumbnail" select="replace($thumbnail-link, 'http://dam-2013.rhodes.edu:8080/xmlui', 'http://dlynx.rhodes.edu:8080/jspui')"/>
+                <url access="preview"><xsl:value-of select="$new-thumbnail"/></url>
+            </xsl:when>
+            <xsl:otherwise>
+                <url access="preview"><xsl:value-of select="$thumbnail-link"/></url>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     
     <!-- Handle -->

--- a/XSLT/rhodes_sternberg_xoai_to_mods.xsl
+++ b/XSLT/rhodes_sternberg_xoai_to_mods.xsl
@@ -130,7 +130,16 @@
     
     <!-- Thumbnail -->
     <xsl:template match='element[@name="bundles"]/element[@name="bundle"][field[@name="name"][text()="THUMBNAIL"]]/element[@name="bitstreams"]/element[@name="bitstream"][1]/field[@name="url"]'>
-        <url access="preview"><xsl:apply-templates/></url>
+        <xsl:variable name="thumbnail-link" select="./text()"/>
+        <xsl:choose>
+            <xsl:when test="starts-with($thumbnail-link, 'http://dam-2013.rhodes.edu:8080/xmlui')">
+                <xsl:variable name="new-thumbnail" select="replace($thumbnail-link, 'http://dam-2013.rhodes.edu:8080/xmlui', 'http://dlynx.rhodes.edu:8080/jspui')"/>
+                <url access="preview"><xsl:value-of select="$new-thumbnail"/></url>
+            </xsl:when>
+            <xsl:otherwise>
+                <url access="preview"><xsl:value-of select="$thumbnail-link"/></url>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     
     <!-- Handle -->


### PR DESCRIPTION
**GitHub Issue**: [DLTN_XSLT-152](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/152)

## What does this Pull Request do?

Replaces the bad thumbnails for some Rhodes sets.

## What's new?

Instead of copying over the thumbnail link, 2 transforms test for a known bad string and replaces them.

## How should this be tested?

1. Look at Travis output.  Does it pass?
2. Run check and harvest vs. these sets with this transform.  Are there any bad URLs?

## Additional Notes:

I haven't ran Travis stuff yet. Also, I haven't ran check and harvest.  Once travis is done, I'll do that, but it's probably good if someone else checks this as well.

## Interested parties

@mlhale7 @CanOfBees 