### PR TITLE
Address DLTN_XSLT-154: Add usage=primary display for isShownAts.

### DIFF
--- a/XSLT/rhodes_dspace_xoai_to_mods.xsl
+++ b/XSLT/rhodes_dspace_xoai_to_mods.xsl
@@ -144,7 +144,7 @@
     <!-- Handle -->
     <xsl:template
         match='element[@name = "dc"]/element[@name = "identifier"]/element[@name = "uri"]/element[@name = "none"]/field[@name = "value"]'>
-        <url access="object in context">
+        <url access="object in context" usage="primary display">
             <xsl:apply-templates/>
         </url>
     </xsl:template>

--- a/XSLT/rhodes_dspace_xoai_to_mods_farnsworth.xsl
+++ b/XSLT/rhodes_dspace_xoai_to_mods_farnsworth.xsl
@@ -161,7 +161,7 @@
     <!-- Handle -->
     <xsl:template
         match='element[@name = "dc"]/element[@name = "identifier"]/element[@name = "uri"]/element[@name = "none"]/field[@name = "value"]'>
-            <url access="object in context">
+            <url access="object in context" usage="primary display">
                 <xsl:apply-templates/>
             </url>
     </xsl:template>

--- a/XSLT/rhodes_sternberg_xoai_to_mods.xsl
+++ b/XSLT/rhodes_sternberg_xoai_to_mods.xsl
@@ -136,7 +136,7 @@
     <!-- Handle -->
     <xsl:template
         match='element[@name = "dc"]/element[@name = "identifier"]/element[@name = "uri"]/element[@name = "none"]/field[@name = "value"]'>
-        <url access="object in context">
+        <url access="object in context" usage="primary display">
             <xsl:apply-templates/>
         </url>
     </xsl:template>


### PR DESCRIPTION
**GitHub Issue**: [DLTN_XSLT-154](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/154)

## What does this Pull Request do?

All Rhodes / Crossroads sets are failing in ingestion3 because ingestion3 expects their to be a usage="primary display" value. This adds it.

## What's new?

A simple string upda0te to all 3 Rhodes transforms.

## How should this be tested?

1. Does Travis pass build? If so, this should mean all the transforms result in a valid document.


## Additional Notes:

Code for this is [here](https://github.com/dpla/ingestion3/blob/2b98f6f2ac661ef0cea3129e7a92ab50f82bfcc9/src/main/scala/dpla/ingestion3/mappers/providers/TnMapping.scala#L226)

## Interested parties

@mlhale7 
