### PR TITLE
Address DLTN_XSLT-160:  initialize unit tests for UTK MODS.

### DIFF
--- a/XSLT/utkmodstomods.xsl
+++ b/XSLT/utkmodstomods.xsl
@@ -133,11 +133,11 @@
             <genre authority="{$pForm/f[matches(text(), $vForm)]/@authority}" valueURI="{$pForm/f[matches(text(), $vForm)]/@uri}">
                 <xsl:value-of select="$pForm/f[matches(text(), $vForm)]/text()"/>
             </genre>
-            <physicalDesciption>
+            <physicalDescription>
                 <form>
                     <xsl:value-of select="$pForm/f[matches(text(), $vForm)]/text()"/>
                 </form>
-            </physicalDesciption>
+            </physicalDescription>
         </xsl:if>
     </xsl:template>
 

--- a/tests/test_data/utk_mods.txt
+++ b/tests/test_data/utk_mods.txt
@@ -1,0 +1,7 @@
+bcpl
+utk_acwiley
+utk_3d
+utk_agee
+utk_agrtfhs
+utk_airscoop
+utk_alumnus

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -65,4 +65,21 @@ testValidityOfUTCQDCtoMODS() {
     done
 }
 
+#UTK Tests
+testValidityOfUTKMODStoMODS() {
+    UTK="test_data/utk_mods.txt"
+    DATADIR="../working_directory/utk"
+    mkdir ${DATADIR}
+    cat $UTK | while read line; do
+        curl "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=mods&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
+    done
+    for filename in ${DATADIR}/*.xml; do
+        TESTFILE="${filename}.test"
+        ${SAXON} ${filename} ${STYLESHEETS}/utkmodstomods.xsl 2>&1 2>/dev/null 1>${TESTFILE}
+        RESPONSE=$(xmllint --noout --schema ${DLTNMODS} ${TESTFILE} 2>&1 1>/dev/null | cat)
+        assertEquals "${RESPONSE}" "${TESTFILE} validates"
+    done
+    rm -rf ${DATADIR}
+}
+
 . shunit2


### PR DESCRIPTION
**GitHub Issue**: [DLTN_XSLT-160](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/160)

## What does this Pull Request do?

This adds baseline things to start unit testing data from UTK before passing things to DPLA.

## What's new?

1. A baseline unit test has been added for UTK.  This works similar to how TSLA's works.  Right now, not all sets are there because of how many problems currently exist with the UTK data.
2. A text file for utk sets.  Eventually, we can think about how to programmatically populate this (pyrepox?)
3. A change to utkmodstomods.xsl so that it can mostly be valid.

## How should this be tested?

1. Look at the unit test. Do you understand it?
2. Does Travis pass?

## Additional Notes:

Again, this is just a start.  This data is awful and this unblocks being able to address those problems one by one.

## Interested parties

@CanOfBees @mlhale7 
