### PR TITLE
Make countryqdc rights more dynamic.

### DIFF
--- a/XSLT/countryqdctomods.xsl
+++ b/XSLT/countryqdctomods.xsl
@@ -42,7 +42,19 @@
       <!-- title -->
       <xsl:apply-templates select="dc:title"/>
       <!-- accessRights -->
-      <xsl:apply-templates select="dcterms:accessRights"/>
+      <xsl:choose>
+        <xsl:when test="dcterms:accessRights">
+          <xsl:apply-templates select="dcterms:accessRights"/>
+        </xsl:when>
+        <xsl:when test="dc:rights">
+          <xsl:apply-templates select="dc:rights"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <accessCondition type="local rights statement">
+            This digital image is the property of the Country Music Hall of Fame® and Museum and is protected by U.S. and international copyright laws. The image may not be downloaded, reproduced, or distributed without permission. To inquire about use permissions and obtain a high-quality version of this file, contact print@countrymusichalloffame.org. Please cite image information in email.
+          </accessCondition>
+        </xsl:otherwise>
+      </xsl:choose>
       <!-- description -->
       <xsl:apply-templates select="dc:description"/>
       <!-- subject(s) -->
@@ -75,6 +87,10 @@
   
   <!-- accessRights -->
   <xsl:template match="dcterms:accessRights">
+    <accessCondition type='local rights statement'><xsl:apply-templates/></accessCondition>
+  </xsl:template>
+
+  <xsl:template match="dc:rights">
     <accessCondition type='local rights statement'><xsl:apply-templates/></accessCondition>
   </xsl:template>
   

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -40,6 +40,13 @@ testValidityOfCountryMusicHallofFame() {
     assertEquals "${RESPONSE}" "${TESTFILE} validates"
 }
 
+testValidityOfCountryMusicHallofFameHatch(){
+    curl "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=cmhf_hatch" 2>&1 2>/dev/null 1>"delete.xml"
+    ${SAXON} delete.xml ${STYLESHEETS}/countryqdctomods.xsl 2>&1 2>/dev/null 1>${TESTFILE}
+    RESPONSE=$(xmllint --noout --schema ${DLTNMODS} ${TESTFILE} 2>&1 1>/dev/null | cat)
+    assertEquals "${RESPONSE}" "${TESTFILE} validates"
+}
+
 # TSLA Tests
 testValidityOfTSLAqdctoMODS() {
     TSLA="test_data/tsla_qdc.txt"


### PR DESCRIPTION
**GitHub Issue**: [DLTN_XSLT-168](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/168)
**GitHub Issue**: [DLTN_XSLT-170](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/170)

## What does this Pull Request do?

Makes Country Music Hall of Fame QDC rights more dynamic.

## What's new?

CMHF is adding a new set.  Not all the records have rights.  This looks for rights in to locations (dcterms:accessRights, dc:rights), and then blankets a rights statement if none exists.

## How should this be tested?

1. Check that Travis passes.

## Interested parties

@mlhale7 @CanOfBees 
