### PR TITLE
Address DLTN_XSLT-190.

### DIFF
--- a/XSLT/utkmodstomods.xsl
+++ b/XSLT/utkmodstomods.xsl
@@ -172,6 +172,12 @@
     <!-- ignore preceding or following sibling titleInfos when titleInfo[@supplied] is present -->
     <xsl:template match="titleInfo[preceding-sibling::titleInfo[@supplied] or following-sibling::titleInfo[@supplied]]"/>
 
+    <xsl:template match="titleInfo[@supplied='yes']">
+        <titleInfo>
+            <title><xsl:value-of select="normalize-space(.)"/></title>
+        </titleInfo>
+    </xsl:template>
+
     <!-- This is a temporary rule to move local accessConditions to abstract and replace all text since it currently has non-UTF8 characters -->
     <xsl:template match="accessCondition[@type='local']">
         <abstract>


### PR DESCRIPTION
**GitHub Issue**: [DLTN_XSLT-190](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/190)

* [TN Mapper Title Override Method](https://github.com/dpla/ingestion3/blob/develop/src/main/scala/dpla/ingestion3/mappers/providers/TnMapping.scala#L184)

## What does this Pull Request do?

This pull request maps all supplied titles to a regular title so that they don't appear as bad records for DPLA.

## What's new?

Collections like Dabney are not getting into DPLA because they have supplied titles that are not mapped to a title field in MAP 4 and thus appear as a bad record.  This maps those titles to the xpath DPLA expects.

## Interested parties

@mlhale7 @CanOfBees 
