### PR TITLE
Add coll28 (TSLA) and coll32 (UTC) to the testing list.

### DIFF
--- a/tests/test_data/tsla_qdc.txt
+++ b/tests/test_data/tsla_qdc.txt
@@ -7,6 +7,7 @@ p15138coll24
 p15138coll25
 p15138coll26
 p15138coll27
+tsla_p15138coll28
 p15138coll29
 tsla_p15138coll31
 p15138coll32

--- a/tests/test_data/utc_qdc.txt
+++ b/tests/test_data/utc_qdc.txt
@@ -29,3 +29,4 @@ utc_p16877coll28
 utc_p16877coll29
 utc_p16877coll30
 utc_p16877coll31
+utc_p16877coll32


### PR DESCRIPTION
**GitHub Issue**: [TSLA September Harvest #192](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/192)

## What does this Pull Request do?

Adds a set from TSLA (tsla_p15138coll28) and from UTC (utc_p16877coll32)that were recently added to Repox.

## What's new?

Two new sets.

## How should this be tested?

Make sure the naming of the set matches the set in Repox.
See if Travis passes.

## Interested parties

@markpbaggett 
