### PR TITLE
Remove ampersand in order to follow NAF and be consistent with dc tra…

### DIFF
--- a/XSLT/tslaqdctomods.xsl
+++ b/XSLT/tslaqdctomods.xsl
@@ -86,7 +86,7 @@
           <!-- spatial -->
           <xsl:apply-templates select="dcterms:spatial"/>
           <recordInfo>
-              <recordContentSource>Tennessee State Library &amp; Archives</recordContentSource>
+              <recordContentSource>Tennessee State Library and Archives</recordContentSource>
               <languageOfCataloging>
                   <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
               </languageOfCataloging>


### PR DESCRIPTION
& in TSLA Transform

## What does this Pull Request do?

Comparing tslaqdctomods.xsl with tsladctomods.xsl revealed that we write in different values for TSLA in our transforms. Since TSLA is established as "Tennessee State Library and Archives" in Library of Congress (http://id.loc.gov/authorities/names/n50066629), I felt that we should use this consistently across our transforms.

## What's new?

An ampersand has been changed to "and".

## How should this be tested?

Use a file from TSLA in the "Sample_Data" folder to confirm that this still works.

## Additional Notes:

One thing I hadn't thought about previously that is potentially problematic is that by writing in the contributor, we are potentially overwriting other institutions that might have given the materials to TSLA. I'll check with everyone on the DLTN committee and make sure that we don't have instances where another institution isn't getting credit.

## Interested parties

@CanOfBees @markpbaggett 
