### PR TITLE
Change url to manifest.json version for XSLT files.

### DIFF
--- a/XSLT/tslaqdctomods.xsl
+++ b/XSLT/tslaqdctomods.xsl
@@ -121,7 +121,7 @@
     <!--identifier-->
     <xsl:template match="dc:identifier[starts-with(normalize-space(.), 'http://')]">
       <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
-      <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/info.json')"/>
+        <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'iiif/info'), '/id', ''), '/manifest.json')"/>
       <url usage="primary" access="object in context"><xsl:apply-templates/></url>
       <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
       <xsl:if test="normalize-space(.) = $catalog//@id">

--- a/XSLT/tslaqdctomods.xsl
+++ b/XSLT/tslaqdctomods.xsl
@@ -121,7 +121,7 @@
     <!--identifier-->
     <xsl:template match="dc:identifier[starts-with(normalize-space(.), 'http://')]">
       <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
-        <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'iiif/info'), '/id', ''), '/manifest.json')"/>
+        <xsl:variable name="iiif-manifest" select="concat(replace(replace(replace(., 'http', 'https'), 'cdm/ref/collection', 'iiif/info'), '/id', ''), '/manifest.json')"/>
       <url usage="primary" access="object in context"><xsl:apply-templates/></url>
       <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
       <xsl:if test="normalize-space(.) = $catalog//@id">

--- a/XSLT/utcqdctomods.xsl
+++ b/XSLT/utcqdctomods.xsl
@@ -266,7 +266,7 @@
   <!-- identifier - location processing -->
   <xsl:template match="dc:identifier[starts-with(normalize-space(.), 'http://')]">
     <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
-    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'iiif/info'), '/id', ''), '/manifest.json')"/>
+    <xsl:variable name="iiif-manifest" select="concat(replace(replace(replace(., 'http', 'https'), 'cdm/ref/collection', 'iiif/info'), '/id', ''), '/manifest.json')"/>
     <url usage="primary" access="object in context"><xsl:apply-templates/></url>
     <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
     <xsl:if test="normalize-space(.) = $catalog//@id">

--- a/XSLT/utcqdctomods.xsl
+++ b/XSLT/utcqdctomods.xsl
@@ -266,7 +266,7 @@
   <!-- identifier - location processing -->
   <xsl:template match="dc:identifier[starts-with(normalize-space(.), 'http://')]">
     <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
-    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/info.json')"/>
+    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'iiif/info'), '/id', ''), '/manifest.json')"/>
     <url usage="primary" access="object in context"><xsl:apply-templates/></url>
     <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
     <xsl:if test="normalize-space(.) = $catalog//@id">


### PR DESCRIPTION
**GitHub Issue**: [228](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/228)
**Jira Issue**: [DPLA-250](https://jirautk.atlassian.net/browse/DPLA-250)

## What does this Pull Request do?

This PR updates utcqdctomods.xsl and tslaqdctomods.xsl so that the correct form of the IIIF link is inserted for records that have a manifest.

## What's new?

## How should this be tested?

A description of what steps someone could take to:

Run the updated transforms against sample XML files and see if the correct URL is present in the MODS files.

## Additional Notes:

While Knox Public, Memphis Public, and Nashville Public also have catalog files (indicating that they have IIIF links), I'm not seeing any XSLT files that generate the IIIF URLs. Please comment on how IIIF links were generated for those institutions and let me know if we need to address them in this PR or a separate one.

## Interested parties

@markpbaggett 
