### PR TITLE
Replace image api links with presentation API links for current trans…

### DIFF
--- a/XSLT/countryqdctomods.xsl
+++ b/XSLT/countryqdctomods.xsl
@@ -135,7 +135,7 @@
   <!-- identifier - location processing -->
   <xsl:template match="dc:identifier[starts-with(., 'http://')]">
     <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
-    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/manifest.json')"/>
+    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'iiif/info'), '/id', ''), '/manifest.json')"/>
     <url usage="primary" access="object in context"><xsl:apply-templates/></url>
     <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
     <xsl:if test="normalize-space(.) = $catalog//@id">

--- a/XSLT/countryqdctomods.xsl
+++ b/XSLT/countryqdctomods.xsl
@@ -135,7 +135,7 @@
   <!-- identifier - location processing -->
   <xsl:template match="dc:identifier[starts-with(., 'http://')]">
     <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
-    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/info.json')"/>
+    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/manifest.json')"/>
     <url usage="primary" access="object in context"><xsl:apply-templates/></url>
     <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
     <xsl:if test="normalize-space(.) = $catalog//@id">

--- a/XSLT/nashvillep15769coll19qdctomods.xsl
+++ b/XSLT/nashvillep15769coll19qdctomods.xsl
@@ -244,7 +244,7 @@
   <!-- identifier - location processing -->
   <xsl:template match="dc:identifier[starts-with(normalize-space(.), 'http://')]">
     <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
-    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/manifest.json')"/>
+    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'iiif/info'), '/id', ''), '/manifest.json')"/>
     <url usage="primary" access="object in context"><xsl:apply-templates/></url>
     <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
     <xsl:if test="normalize-space(.) = $catalog//@id">

--- a/XSLT/nashvillep15769coll19qdctomods.xsl
+++ b/XSLT/nashvillep15769coll19qdctomods.xsl
@@ -244,7 +244,7 @@
   <!-- identifier - location processing -->
   <xsl:template match="dc:identifier[starts-with(normalize-space(.), 'http://')]">
     <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
-    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/info.json')"/>
+    <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/manifest.json')"/>
     <url usage="primary" access="object in context"><xsl:apply-templates/></url>
     <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
     <xsl:if test="normalize-space(.) = $catalog//@id">

--- a/XSLT/thumbnailscontentdmdctomods.xsl
+++ b/XSLT/thumbnailscontentdmdctomods.xsl
@@ -20,7 +20,7 @@
             <xsl:variable name="pointer" select="substring-after($recordinfo,'/id/')"/>
             <url access="preview"><xsl:value-of select="concat($contentdmroot,'/utils/getthumbnail/collection/',$alias,'/id/',$pointer)"/></url> 
             <!--CONTENTdm thumbnail url-->
-            <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/manifest.json')"/>
+            <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'iiif/info'), '/id', ''), '/manifest.json')"/>
             <xsl:if test="normalize-space(.) = $catalogs//@id">
                 <url note="iiif-manifest"><xsl:value-of select="$iiif-manifest"/></url>
             </xsl:if>

--- a/XSLT/thumbnailscontentdmdctomods.xsl
+++ b/XSLT/thumbnailscontentdmdctomods.xsl
@@ -20,7 +20,7 @@
             <xsl:variable name="pointer" select="substring-after($recordinfo,'/id/')"/>
             <url access="preview"><xsl:value-of select="concat($contentdmroot,'/utils/getthumbnail/collection/',$alias,'/id/',$pointer)"/></url> 
             <!--CONTENTdm thumbnail url-->
-            <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/info.json')"/>
+            <xsl:variable name="iiif-manifest" select="concat(replace(replace(., 'cdm/ref/collection', 'digital/iiif'), '/id', ''), '/manifest.json')"/>
             <xsl:if test="normalize-space(.) = $catalogs//@id">
                 <url note="iiif-manifest"><xsl:value-of select="$iiif-manifest"/></url>
             </xsl:if>


### PR DESCRIPTION
**GitHub Issue**: [DLTN-228](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/228)


## What does this Pull Request do?

Replaces the info.json link with a manifest.json link for all remaining transforms that create an info.json link.

## What's new?

Three files have been modified to include this.  I have questions about some of the set specific Nashville transforms that don't have this currently, but that's out of scope.

## How should this be tested?

Run the updated transforms against sample XML files and see if the correct URL is present in the MODS files.

## Additional Notes:

I'm intentionally not changing protocols here.  Broadly, I have concerns about doing that.  We are running this against whatever link is pointed to in the incoming OAI and doing a replace.  Also, the links here are plain text (not input boxes) so there are no security concerns.

## Interested parties
@mlhale7 
