### PR TITLE
Whats wrong with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
       - libxml2-utils
       - shunit2
       - openjdk-8-jre
+      - openssl
 
 notifications:
   email:

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -61,9 +61,9 @@ testValidityOfTSLAqdctoMODS() {
     DATADIR="../working_directory/tsla_qdc"
     mkdir ${DATADIR}
     cat $TSLA | while read line; do
-        curl "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
+        curl "http://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
         TOPOFFILE=$(head "$DATADIR/$line.xml")
-        CURLRESPONSE=$(curl -s -o /dev/null -I -w "%{http_code}" "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
+        CURLRESPONSE=$(curl -s -o /dev/null -I -w "%{http_code}" "http://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
         echo $CURLRESPONSE
     done
     for filename in ${DATADIR}/*.xml; do

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -12,6 +12,14 @@ testJavaInstalled() {
     assertNotNull $(which java)
 }
 
+testShunitIntalled() {
+    assertNotNull $(which shunit2)
+}
+
+testCurlInstalled() {
+    assertNotNull $(which curl)
+}
+
 # Rhodes and Crossroads to Freedom
 testValidityOfSternberg() {
     ${SAXON} ${SAMPLEDATA}/Rhodes/sternberg.xml ${STYLESHEETS}/rhodes_sternberg_xoai_to_mods.xsl 2>&1 2>/dev/null 1>${TESTFILE}

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -62,6 +62,7 @@ testValidityOfTSLAqdctoMODS() {
     mkdir ${DATADIR}
     cat $TSLA | while read line; do
         curl "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
+        cat "$DATADIR/$line.xml"
     done
     for filename in ${DATADIR}/*.xml; do
         ${SAXON} ${filename} ${STYLESHEETS}/tslaqdctomods.xsl 2>&1 2>/dev/null 1>${TESTFILE}

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -49,7 +49,7 @@ testValidityOfCountryMusicHallofFame() {
 }
 
 testValidityOfCountryMusicHallofFameHatch(){
-    curl "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=cmhf_hatch" 2>&1 2>/dev/null 1>"delete.xml"
+    curl "http://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=cmhf_hatch" 2>&1 2>/dev/null 1>"delete.xml"
     ${SAXON} delete.xml ${STYLESHEETS}/countryqdctomods.xsl 2>&1 2>/dev/null 1>${TESTFILE}
     RESPONSE=$(xmllint --noout --schema ${DLTNMODS} ${TESTFILE} 2>&1 1>/dev/null | cat)
     assertEquals "${RESPONSE}" "${TESTFILE} validates"

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -63,7 +63,7 @@ testValidityOfTSLAqdctoMODS() {
     cat $TSLA | while read line; do
         curl "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
         TOPOFFILE=$(head "$DATADIR/$line.xml")
-        CURLRESPONSE=$(curl -I "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
+        CURLRESPONSE=$(curl -s -o /dev/null -I -w "%{http_code}" "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
         echo $CURLRESPONSE
     done
     for filename in ${DATADIR}/*.xml; do

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -63,7 +63,7 @@ testValidityOfTSLAqdctoMODS() {
     cat $TSLA | while read line; do
         curl "http://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
         TOPOFFILE=$(head "$DATADIR/$line.xml")
-        CURLRESPONSE=$(curl -s -o /dev/null -I -w "%{http_code}" "http://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
+        CURLRESPONSE=$(curl -s -o /dev/null -I -w "%{http_code}" "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
         echo $CURLRESPONSE
     done
     for filename in ${DATADIR}/*.xml; do

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -63,7 +63,7 @@ testValidityOfTSLAqdctoMODS() {
     cat $TSLA | while read line; do
         curl "http://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
         TOPOFFILE=$(head "$DATADIR/$line.xml")
-        CURLRESPONSE=$(curl -s -o /dev/null -I -w "%{http_code}" "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
+        CURLRESPONSE=$(curl -s -o -k /dev/null -I -w --insecure "%{http_code}" "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
         echo $CURLRESPONSE
     done
     for filename in ${DATADIR}/*.xml; do

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -63,7 +63,8 @@ testValidityOfTSLAqdctoMODS() {
     cat $TSLA | while read line; do
         curl "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
         TOPOFFILE=$(head "$DATADIR/$line.xml")
-        echo $TOPOFFILE
+        CURLRESPONSE=$(curl -I "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
+        echo $CURLRESPONSE
     done
     for filename in ${DATADIR}/*.xml; do
         ${SAXON} ${filename} ${STYLESHEETS}/tslaqdctomods.xsl 2>&1 2>/dev/null 1>${TESTFILE}

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -62,7 +62,8 @@ testValidityOfTSLAqdctoMODS() {
     mkdir ${DATADIR}
     cat $TSLA | while read line; do
         curl "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
-        cat "$DATADIR/$line.xml"
+        TOPOFFILE=$(head "$DATADIR/$line.xml")
+        echo $TOPOFFILE
     done
     for filename in ${DATADIR}/*.xml; do
         ${SAXON} ${filename} ${STYLESHEETS}/tslaqdctomods.xsl 2>&1 2>/dev/null 1>${TESTFILE}

--- a/tests/validate_scenarios.sh
+++ b/tests/validate_scenarios.sh
@@ -63,8 +63,7 @@ testValidityOfTSLAqdctoMODS() {
     cat $TSLA | while read line; do
         curl "http://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
         TOPOFFILE=$(head "$DATADIR/$line.xml")
-        CURLRESPONSE=$(curl -s -o -k /dev/null -I -w --insecure "%{http_code}" "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
-        echo $CURLRESPONSE
+        CURLRESPONSE=$(curl -s -o /dev/null -I -w --insecure "%{http_code}" "http://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=oai_qdc&set=$line")
     done
     for filename in ${DATADIR}/*.xml; do
         ${SAXON} ${filename} ${STYLESHEETS}/tslaqdctomods.xsl 2>&1 2>/dev/null 1>${TESTFILE}
@@ -80,7 +79,7 @@ testValidityOfUTCQDCtoMODS() {
     DATADIR="../working_directory/utc"
     mkdir ${DATADIR}
     cat $UTK | while read line; do
-        curl "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=mods&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
+        curl "http://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=mods&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
     done
     for filename in ${DATADIR}/*.xml; do
         TESTFILE="${filename}.test"
@@ -97,7 +96,7 @@ testValidityOfUTKMODStoMODS() {
     DATADIR="../working_directory/utk"
     mkdir ${DATADIR}
     cat $UTK | while read line; do
-        curl "https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=mods&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
+        curl "http://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=mods&set=$line" 2>&1 2>/dev/null 1>"$DATADIR/$line.xml"
     done
     for filename in ${DATADIR}/*.xml; do
         TESTFILE="${filename}.test"


### PR DESCRIPTION
**GitHub Issue**: [DLTN-232](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/232)

## What does this Pull Request do?

Makes tests with Travis work again.

## What's new?

A few weeks ago, Travis started failing all of a sudden.  I mistakenly blamed this on Travis, but on closer inspection that's not the case.  When Travis would make a request to our installation of Repox, it would respond with a 000 HTTP status code.  While this can be caused by a variety of things, in our case it's based on the SSL library in the Repox jar.  Repox uses an SSL library that is very strict on its interpretation of how SSL should be implemented.  This has caused issues for others before (Vermont), but has never been a problem for us. A few weeks ago, some things happened with SSL and while I'm not clear on all of this, I wouldn't be surprised if it relates to why this is suddenly an issue.

To solve this, I've simply made the calls be over HTTP rather than SSL. 

## How should this be tested?

Check that Travis tests now work.

## Additional Notes:

In theory, this could also cause issues for DPLA depending on how they have things implemented on their end.  I get no errors from Repox when making calls over HTTPS, but Travis does.  It's really going to depend on how they have things setup on their end.

## Interested parties

@mlhale7 
