### PR TITLE
Add "s" to URL.

### DIFF
--- a/XSLT/coredctomods.xsl
+++ b/XSLT/coredctomods.xsl
@@ -556,7 +556,7 @@
                     </xsl:when>
                     <!-- keep public domain test but map to no copyright - united states -->
                     <xsl:when test="contains($vText, 'public domain')">
-                        <accessCondition type="use and reproduction" xlink:href="http://rightsstatement.org/vocab/NoC-US/1.0/">No Copyright - United States</accessCondition>
+                        <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/NoC-US/1.0/">No Copyright - United States</accessCondition>
                     </xsl:when>
                     <xsl:otherwise>
                         <xsl:if test="$vText != ''">


### PR DESCRIPTION
**GitHub Issue**: [247](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/247)

## What does this Pull Request do?

This PR fixes a rightsstatements URI in the coredctomods transform. A "s" was missing for the URI associated with "No Copyright - United States" and this was causing several records from MTSU's p15838coll7 to be rejected by DPLA. With the added "s", these records should be valid.

## How should this be tested?

Transform sample records from p15838coll7 to MODS and see if the resulting URI for records previously throwing errors is "http://rightsstatements.org/vocab/NoC-US/1.0/". Here are a few test records in DC -
[p15838coll7TestRecords.txt](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/files/5631698/p15838coll7TestRecords.txt)

