### PR TITLE
Tsu transform

### DIFF
--- a/Sample_Data/TSU/TSUSample_DigCollYearbooksCatalogues.xml
+++ b/Sample_Data/TSU/TSUSample_DigCollYearbooksCatalogues.xml
@@ -1,0 +1,582 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+    <responseDate>2020-12-09T15:21:54Z</responseDate>
+    <request verb="ListRecords" set="publication:library-digital-collections" metadataPrefix="oai_dc">https://digitalscholarship.tnstate.edu/do/oai/</request>
+    <ListRecords>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:library-digital-collections-1079</identifier>
+                <datestamp>2020-05-12T15:56:02Z</datestamp>
+                <setSpec>publication:library-digital-collections</setSpec>
+                <setSpec>publication:library-historical-collections</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Multi Women Sports</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:description>Multi Women Sports.</dc:description>
+                    <dc:date>1939-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>image/jpeg</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/library-digital-collections/80</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/context/library-digital-collections/article/1079/type/native/viewcontent</dc:identifier>
+                    <dc:rights>Physical Rights are retained by Special Collections and Archives - Tennessee State University. CopyrightÂ© is retained in accordance with U.S. Copyright laws. To order a reproduction or inquire about permission to publish, please contact shull@tnstate.edu. (Please cite object file name of collection).</dc:rights>
+                    <dc:source>Tennessee State University Library Digital Collections</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Sports; Physical education;</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/library-digital-collections/1079/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:library-digital-collections-1026</identifier>
+                <datestamp>2020-05-12T15:56:02Z</datestamp>
+                <setSpec>publication:library-digital-collections</setSpec>
+                <setSpec>publication:library-historical-collections</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>President Hale and Tennessee State's First Faculty</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:description>Black and White Photograph of President Hale and the School's First Faculty Members.</dc:description>
+                    <dc:date>1912-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>image/jpeg</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/library-digital-collections/27</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/context/library-digital-collections/article/1026/type/native/viewcontent</dc:identifier>
+                    <dc:rights>Physical Rights are retained by Special Collections and Archives - Tennessee State University. CopyrightÂ© is retained in accordance with U.S. Copyright laws. To order a reproduction or inquire about permission to publish, please contact shull@tnstate.edu. (Please cite object file name of collection).</dc:rights>
+                    <dc:source>Tennessee State University Library Digital Collections</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>College administrators</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/library-digital-collections/1026/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:library-digital-collections-1027</identifier>
+                <datestamp>2020-05-12T15:56:02Z</datestamp>
+                <setSpec>publication:library-digital-collections</setSpec>
+                <setSpec>publication:library-historical-collections</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>William J. Hale and family</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:description>W. J. Hale, the First President of Tennesse Agricultural and Industrial State Normal School (Now Tennessee State University), Was Married to the Former Hattie E. Hodgkins in 1913. He Is Pictured Here With His Wife and Young Daughter. They Also Had Two Sons.</dc:description>
+                    <dc:date>2020-05-12T22:26:32Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>image/jpeg</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/library-digital-collections/28</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/context/library-digital-collections/article/1027/type/native/viewcontent</dc:identifier>
+                    <dc:rights>Physical Rights are retained by Special Collections and Archives - Tennessee State University. CopyrightÂ© is retained in accordance with U.S. Copyright laws. To order a reproduction or inquire about permission to publish, please contact shull@tnstate.edu. (Please cite object file name of collection).</dc:rights>
+                    <dc:source>Tennessee State University Library Digital Collections</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>College presidents;Family</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/library-digital-collections/1027/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:library-digital-collections-1028</identifier>
+                <datestamp>2020-05-12T15:56:02Z</datestamp>
+                <setSpec>publication:library-digital-collections</setSpec>
+                <setSpec>publication:library-historical-collections</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>William J. Hale, President</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:description>A Black and White Photograph of William J. Hale, the First President (1912-1943) of Tennessee State University.</dc:description>
+                    <dc:date>1912-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>image/jpeg</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/library-digital-collections/29</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/context/library-digital-collections/article/1028/type/native/viewcontent</dc:identifier>
+                    <dc:rights>Physical Rights are retained by Special Collections and Archives - Tennessee State University. CopyrightÂ© is retained in accordance with U.S. Copyright laws. To order a reproduction or inquire about permission to publish, please contact shull@tnstate.edu. (Please cite object file name of collection).</dc:rights>
+                    <dc:source>Tennessee State University Library Digital Collections</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>College presidents</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/library-digital-collections/1028/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:library-digital-collections-1029</identifier>
+                <datestamp>2020-05-12T15:56:02Z</datestamp>
+                <setSpec>publication:library-digital-collections</setSpec>
+                <setSpec>publication:library-historical-collections</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Soon After the Opening, 1912</dc:title>
+                    <dc:creator>Tennessee State Univeristy</dc:creator>
+                    <dc:description>Black and White Photograph of an Opening Class, June 1912.</dc:description>
+                    <dc:date>1912-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>image/jpeg</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/library-digital-collections/30</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/context/library-digital-collections/article/1029/type/native/viewcontent</dc:identifier>
+                    <dc:rights>Physical Rights are retained by Special Collections and Archives - Tennessee State University. CopyrightÂ© is retained in accordance with U.S. Copyright laws. To order a reproduction or inquire about permission to publish, please contact shull@tnstate.edu. (Please cite object file name of collection).</dc:rights>
+                    <dc:source>Tennessee State University Library Digital Collections</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Students</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/library-digital-collections/1029/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:library-digital-collections-1030</identifier>
+                <datestamp>2020-05-12T15:56:02Z</datestamp>
+                <setSpec>publication:library-digital-collections</setSpec>
+                <setSpec>publication:library-historical-collections</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Men's Dormitory, 1912</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:description>Black and White Photograph of the Men's Dormitory Taken in 1912.</dc:description>
+                    <dc:date>1912-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>image/jpeg</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/library-digital-collections/31</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/context/library-digital-collections/article/1030/type/native/viewcontent</dc:identifier>
+                    <dc:rights>Physical Rights are retained by Special Collections and Archives - Tennessee State University. CopyrightÂ© is retained in accordance with U.S. Copyright laws. To order a reproduction or inquire about permission to publish, please contact shull@tnstate.edu. (Please cite object file name of collection).</dc:rights>
+                    <dc:source>Tennessee State University Library Digital Collections</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Dormitories;Universities &amp; colleges</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/library-digital-collections/1030/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:library-digital-collections-1031</identifier>
+                <datestamp>2020-05-12T15:56:02Z</datestamp>
+                <setSpec>publication:library-digital-collections</setSpec>
+                <setSpec>publication:library-historical-collections</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Students and Graduates of the Normal Department of Tennessee Agricultural and Industrial State Normal School, 1913-1914</dc:title>
+                    <dc:creator>Lay Bros Photography</dc:creator>
+                    <dc:description>Students and Graduates of the Tennessee Agricultural and Industrial State Normal School Pose at Graduation, 1914.</dc:description>
+                    <dc:date>1914-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>image/jpeg</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/library-digital-collections/32</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/context/library-digital-collections/article/1031/type/native/viewcontent</dc:identifier>
+                    <dc:rights>Physical Rights are retained by Special Collections and Archives - Tennessee State University. CopyrightÂ© is retained in accordance with U.S. Copyright laws. To order a reproduction or inquire about permission to publish, please contact shull@tnstate.edu. (Please cite object file name of collection).</dc:rights>
+                    <dc:source>Tennessee State University Library Digital Collections</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Students</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/library-digital-collections/1031/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:library-digital-collections-1032</identifier>
+                <datestamp>2020-05-12T15:56:02Z</datestamp>
+                <setSpec>publication:library-digital-collections</setSpec>
+                <setSpec>publication:library-historical-collections</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Normal School Graduating Class of 1914, Tennessee Agricultural and Industrial State Normal School</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:description>Pictured Here Is the Graduating Class of the Normal Department of Tennessee Agricultural and Industrial State Normal School in 1914. School President William J. Hale Stands in the Center of the Photograph. This School Was a Precursor to Tennessee State University.</dc:description>
+                    <dc:date>1914-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>image/jpeg</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/library-digital-collections/33</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/context/library-digital-collections/article/1032/type/native/viewcontent</dc:identifier>
+                    <dc:rights>Physical Rights are retained by Special Collections and Archives - Tennessee State University. CopyrightÂ© is retained in accordance with U.S. Copyright laws. To order a reproduction or inquire about permission to publish, please contact shull@tnstate.edu. (Please cite object file name of collection).</dc:rights>
+                    <dc:source>Tennessee State University Library Digital Collections</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Graduation ceremonies; Universities &amp; colleges</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/library-digital-collections/1032/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:library-digital-collections-1033</identifier>
+                <datestamp>2020-05-12T15:56:02Z</datestamp>
+                <setSpec>publication:library-digital-collections</setSpec>
+                <setSpec>publication:library-historical-collections</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Normal School Commencement, 1915</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:description>Black and white Photograph of the Normal School Commencement Taken in 1915.</dc:description>
+                    <dc:date>1915-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>image/jpeg</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/library-digital-collections/34</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/context/library-digital-collections/article/1033/type/native/viewcontent</dc:identifier>
+                    <dc:rights>Physical Rights are retained by Special Collections and Archives - Tennessee State University. CopyrightÂ© is retained in accordance with U.S. Copyright laws. To order a reproduction or inquire about permission to publish, please contact shull@tnstate.edu. (Please cite object file name of collection).</dc:rights>
+                    <dc:source>Tennessee State University Library Digital Collections</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Graduation ceremonies;Universities &amp; colleges</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/library-digital-collections/1033/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:yearbooks-1023</identifier>
+                <datestamp>2019-09-20T22:24:04Z</datestamp>
+                <setSpec>publication:yearbooks</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>The Tennessean 1965</dc:title>
+                    <dc:creator>Tennessee Agricultural and Industrial State University</dc:creator>
+                    <dc:date>1965-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/yearbooks/24</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1023&amp;context=yearbooks</dc:identifier>
+                    <dc:source>Tennessee State University Yearbooks</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee Agricultural and Industrial State University</dc:subject>
+                    <dc:subject>yearbooks</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/yearbooks/1023/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:yearbooks-1013</identifier>
+                <datestamp>2019-09-20T22:24:04Z</datestamp>
+                <setSpec>publication:yearbooks</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>The Tennessean 1955</dc:title>
+                    <dc:creator>Tennessee Agricultural and Industrial State University</dc:creator>
+                    <dc:date>1955-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/yearbooks/14</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1013&amp;context=yearbooks</dc:identifier>
+                    <dc:source>Tennessee State University Yearbooks</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee Agricultural and Industrial State University</dc:subject>
+                    <dc:subject>yearbooks</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/yearbooks/1013/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:yearbooks-1048</identifier>
+                <datestamp>2019-09-22T03:21:21Z</datestamp>
+                <setSpec>publication:yearbooks</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>The Tennessean 1991</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:date>1991-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/yearbooks/49</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1048&amp;context=yearbooks</dc:identifier>
+                    <dc:source>Tennessee State University Yearbooks</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee State University</dc:subject>
+                    <dc:subject>yearbooks</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/yearbooks/1048/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:yearbooks-1005</identifier>
+                <datestamp>2019-09-20T22:24:04Z</datestamp>
+                <setSpec>publication:yearbooks</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Ayeni 1941</dc:title>
+                    <dc:creator>Tennessee Agricultural and Industrial State College</dc:creator>
+                    <dc:date>1941-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/yearbooks/6</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1005&amp;context=yearbooks</dc:identifier>
+                    <dc:source>Tennessee State University Yearbooks</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee Agricultural and Industrial State College</dc:subject>
+                    <dc:subject>yearbooks</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/yearbooks/1005/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:yearbooks-1006</identifier>
+                <datestamp>2019-09-20T22:24:04Z</datestamp>
+                <setSpec>publication:yearbooks</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Ayeni 1942</dc:title>
+                    <dc:creator>Tennessee Agricultural and Industrial State College</dc:creator>
+                    <dc:date>1942-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/yearbooks/7</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1006&amp;context=yearbooks</dc:identifier>
+                    <dc:source>Tennessee State University Yearbooks</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee Agricultural and Industrial State College</dc:subject>
+                    <dc:subject>yearbooks</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/yearbooks/1006/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:yearbooks-1037</identifier>
+                <datestamp>2019-09-22T03:21:21Z</datestamp>
+                <setSpec>publication:yearbooks</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>The Tennessean 1979</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:date>1979-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/yearbooks/38</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1037&amp;context=yearbooks</dc:identifier>
+                    <dc:source>Tennessee State University Yearbooks</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee State University</dc:subject>
+                    <dc:subject>yearbooks</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/yearbooks/1037/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:yearbooks-1051</identifier>
+                <datestamp>2019-09-22T03:21:21Z</datestamp>
+                <setSpec>publication:yearbooks</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>The Tennessean 1994</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:date>1994-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/yearbooks/52</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1051&amp;context=yearbooks</dc:identifier>
+                    <dc:source>Tennessee State University Yearbooks</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee State University</dc:subject>
+                    <dc:subject>yearbooks</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/yearbooks/1051/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:graduatecatalogues-1002</identifier>
+                <datestamp>2019-09-29T01:48:21Z</datestamp>
+                <setSpec>publication:graduatecatalogues</setSpec>
+                <setSpec>publication:allcatalogues</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Graduate Catalogue 2011-2013</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:date>2013-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/graduatecatalogues/3</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1002&amp;context=graduatecatalogues</dc:identifier>
+                    <dc:source>Tennessee State University Graduate Catalogues</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee State University</dc:subject>
+                    <dc:subject>catalogues</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/graduatecatalogues/1002/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:graduatecatalogues-1001</identifier>
+                <datestamp>2019-09-29T01:48:13Z</datestamp>
+                <setSpec>publication:graduatecatalogues</setSpec>
+                <setSpec>publication:allcatalogues</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Graduate Catalogue 2009-2011</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:date>2011-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/graduatecatalogues/2</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1001&amp;context=graduatecatalogues</dc:identifier>
+                    <dc:source>Tennessee State University Graduate Catalogues</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee State University</dc:subject>
+                    <dc:subject>catalogues</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/graduatecatalogues/1001/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:graduatecatalogues-1003</identifier>
+                <datestamp>2019-09-29T01:48:50Z</datestamp>
+                <setSpec>publication:graduatecatalogues</setSpec>
+                <setSpec>publication:allcatalogues</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Graduate Catalogue 2013-2015</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:date>2015-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/graduatecatalogues/4</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1003&amp;context=graduatecatalogues</dc:identifier>
+                    <dc:source>Tennessee State University Graduate Catalogues</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee State University</dc:subject>
+                    <dc:subject>catalogues</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/graduatecatalogues/1003/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:graduatecatalogues-1004</identifier>
+                <datestamp>2019-09-29T01:49:00Z</datestamp>
+                <setSpec>publication:graduatecatalogues</setSpec>
+                <setSpec>publication:allcatalogues</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Graduate Catalogue 2015-2017</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:date>2017-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/graduatecatalogues/5</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1004&amp;context=graduatecatalogues</dc:identifier>
+                    <dc:source>Tennessee State University Graduate Catalogues</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee State University</dc:subject>
+                    <dc:subject>catalogues</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/graduatecatalogues/1004/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:graduatecatalogues-1005</identifier>
+                <datestamp>2019-09-29T01:49:06Z</datestamp>
+                <setSpec>publication:graduatecatalogues</setSpec>
+                <setSpec>publication:allcatalogues</setSpec>
+                <setSpec>publication:archives</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Graduate Catalogue 2017-2019</dc:title>
+                    <dc:creator>Tennessee State University</dc:creator>
+                    <dc:date>2019-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/graduatecatalogues/6</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1005&amp;context=graduatecatalogues</dc:identifier>
+                    <dc:source>Tennessee State University Graduate Catalogues</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee State University</dc:subject>
+                    <dc:subject>catalogues</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/graduatecatalogues/1005/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:undergraduatecatalogues-1012</identifier>
+                <datestamp>2019-10-16T14:30:05Z</datestamp>
+                <setSpec>publication:allcatalogues</setSpec>
+                <setSpec>publication:archives</setSpec>
+                <setSpec>publication:undergraduatecatalogues</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Undergraduate Catalogue 1993-1995</dc:title>
+                    <dc:date>1995-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/undergraduatecatalogues/13</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1012&amp;context=undergraduatecatalogues</dc:identifier>
+                    <dc:source>Tennessee State University Undergraduate Catalogues</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee State University</dc:subject>
+                    <dc:subject>Catalogues</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/undergraduatecatalogues/1012/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        <record>
+            <header>
+                <identifier>oai:digitalscholarship.tnstate.edu:undergraduatecatalogues-1037</identifier>
+                <datestamp>2019-10-16T14:30:05Z</datestamp>
+                <setSpec>publication:allcatalogues</setSpec>
+                <setSpec>publication:archives</setSpec>
+                <setSpec>publication:undergraduatecatalogues</setSpec>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Undergraduate Catalogue 1954-1955</dc:title>
+                    <dc:date>1955-01-01T08:00:00Z</dc:date>
+                    <dc:type>text</dc:type>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/undergraduatecatalogues/38</dc:identifier>
+                    <dc:identifier>https://digitalscholarship.tnstate.edu/cgi/viewcontent.cgi?article=1037&amp;context=undergraduatecatalogues</dc:identifier>
+                    <dc:source>Tennessee State University Undergraduate Catalogues</dc:source>
+                    <dc:publisher>Digital Scholarship @ Tennessee State University</dc:publisher>
+                    <dc:subject>Tennessee Agricultural and Industrial State University</dc:subject>
+                    <dc:subject>Catalogues</dc:subject>
+                    <dc:description>https://digitalscholarship.tnstate.edu/undergraduatecatalogues/1037/thumbnail.jpg</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+    </ListRecords>
+</OAI-PMH>

--- a/XSLT/tsudctomods.xsl
+++ b/XSLT/tsudctomods.xsl
@@ -2,23 +2,19 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/"
     version="2.0" xmlns="http://www.loc.gov/mods/v3">
-    
     <!-- output settings -->
     <xsl:output encoding="UTF-8" method="xml" omit-xml-declaration="yes" indent="yes"/>
     <xsl:strip-space elements="*"/>
-    
     <!-- identity transform -->
     <xsl:template match="@* | node()">
         <xsl:copy>
             <xsl:apply-templates select="@* | node()"/>
         </xsl:copy>
     </xsl:template>
-    
     <!-- normalize all the text! -->
     <xsl:template match="text()">
         <xsl:value-of select="normalize-space(.)"/>
     </xsl:template>
-    
     <!-- match metadata -->
     <xsl:template match="oai_dc:dc">
         <!-- match the document root and return a MODS record -->
@@ -26,61 +22,55 @@
             xmlns:xlink="http://www.w3.org/1999/xlink"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
-            
             <!-- title -->
             <xsl:apply-templates select="dc:title"/>
-            
-            <!-- thumbnail and object URL  -->
-            <location>
-            <xsl:apply-templates select="dc:description[starts-with(normalize-space(.), 'https://')] | dc:identifier[starts-with(normalize-space(.), 'https://')]"/>
-            </location>
-            
+            <!-- identifier -->
+            <xsl:apply-templates select="dc:identifier[contains(., 'viewcontent.cgi')]"/>
+            <!-- abstract -->
+            <xsl:apply-templates select="dc:description[not(starts-with(., 'http'))]"/>
             <!-- creator -->
             <xsl:apply-templates select="dc:creator"/>
-            
             <!-- originInfo> -->
             <xsl:apply-templates select="dc:date"/>
-            
             <!-- subject(s) -->
             <xsl:apply-templates select="dc:subject"/>
-            
             <!-- relatedItem -->
             <xsl:apply-templates select="dc:source"/>
-            
+            <!-- location -->
+            <location>
+                <xsl:apply-templates select="dc:identifier[matches(., '[0-9]$')]"/>
+                <xsl:apply-templates select="dc:description[(ends-with(., 'jpg'))]"/>        
+            </location>
             <!-- publisher or recordContentSource -->
             <recordInfo><recordContentSource>Tennessee State University</recordContentSource></recordInfo>
-            
             <!-- rights or accessCondition -->
             <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
-            
         </mods>
+        
     </xsl:template>
-    
     <!-- title -->
     <xsl:template match="dc:title">
         <titleInfo><title><xsl:apply-templates/></title></titleInfo>
     </xsl:template>
-    
-    <!-- URLs -->
-    <xsl:template match="dc:description | dc:identifier">
-        <xsl:choose>
-            <xsl:when test="ends-with(., '.jpg')">
-                <url access="preview"><xsl:apply-templates/></url>
-            </xsl:when>
-            <xsl:when test="matches(., '[0-9]$')">
-                <url usage="primary" access="object in context"><xsl:apply-templates/></url>
-            </xsl:when>
-        </xsl:choose>
+    <!-- Object in context -->
+    <xsl:template match="dc:identifier[matches(., '[0-9]$')]">
+        <url usage="primary" access="object in context"><xsl:apply-templates/></url>
     </xsl:template>
-     
-    <!-- abstract
-    <xsl:template match="dc:description">
-        <xsl:choose>
-            <xsl:when test="(., '^[A-Z]')">
-                <abstract><xsl:apply-templates/></abstract>
-            </xsl:when>
-        </xsl:choose>
-    </xsl:template> -->
+    
+    <!-- abstract or thumbnail -->
+    <xsl:template match="dc:description[not(starts-with(., 'http'))]">
+        <abstract><xsl:apply-templates/></abstract>
+    </xsl:template>
+    
+    <!-- thumbnail -->
+    <xsl:template match="dc:description[ends-with(., 'jpg')]">
+        <url access="preview"><xsl:apply-templates/></url>
+    </xsl:template>
+    
+    <!-- other identifier -->
+    <xsl:template match="dc:identifier[contains(., 'viewcontent.cgi')]">
+        <identifier><xsl:apply-templates/></identifier>
+    </xsl:template>
     
     <!-- creator -->
     <xsl:template match="dc:creator">
@@ -94,7 +84,13 @@
     
     <!-- originInfo -->
     <xsl:template match="dc:date">
-        <originInfo><dateCreated><xsl:copy-of select="substring(., 1, string-length(.) -10)"></xsl:copy-of></dateCreated></originInfo>
+        <xsl:choose>
+            <xsl:when test="starts-with(., '19')">
+                <originInfo><dateCreated>
+                    <xsl:copy-of select="substring(., 1, string-length(.) -10)"></xsl:copy-of>
+                </dateCreated></originInfo>
+            </xsl:when>
+        </xsl:choose>
     </xsl:template>
     
     <!-- subject(s) -->
@@ -143,5 +139,4 @@
     <xsl:template match="dc:publisher">
         <recordInfo><recordContentSource><xsl:apply-templates/></recordContentSource></recordInfo>
     </xsl:template>
-    
 </xsl:stylesheet>

--- a/XSLT/tsudctomods.xsl
+++ b/XSLT/tsudctomods.xsl
@@ -73,10 +73,10 @@
             <xsl:when test="contains(., 'library-digital-collections/')">
                 <typeOfResource>still image</typeOfResource>
             </xsl:when>
-            <xsl:when test="contains(., 'catalogues/')">
+            <xsl:when test="contains(., 'catalogues')">
                 <typeOfResource>text</typeOfResource>
             </xsl:when>
-            <xsl:when test="contains(., 'yearbooks/')">
+            <xsl:when test="contains(., 'yearbooks')">
                 <typeOfResource>text</typeOfResource>
             </xsl:when>
         </xsl:choose>

--- a/XSLT/tsudctomods.xsl
+++ b/XSLT/tsudctomods.xsl
@@ -65,19 +65,19 @@
     <!-- identifier / object URL / typeOfResource based off collection -->
     <xsl:template match='dc:identifier'>
         <xsl:choose>
+            <xsl:when test="contains(., 'library-digital-collections/')">
+                <typeOfResource>still image</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(., 'catalogues/')">
+                <typeOfResource>text</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(., 'yearbooks/')">
+                <typeOfResource>text</typeOfResource>
+            </xsl:when>
             <xsl:when test="matches(., '[0-9]$')">
                 <location>
                     <url usage="primary" access="object in context"><xsl:apply-templates/></url>
                 </location>
-            </xsl:when>
-            <xsl:when test="contains(., 'library-digital-collections/')">
-                <typeOfResource>still image</typeOfResource>
-            </xsl:when>
-            <xsl:when test="contains(., 'catalogues')">
-                <typeOfResource>text</typeOfResource>
-            </xsl:when>
-            <xsl:when test="contains(., 'yearbooks')">
-                <typeOfResource>text</typeOfResource>
             </xsl:when>
         </xsl:choose>
     </xsl:template>
@@ -108,11 +108,7 @@
     
     <!-- originInfo -->
     <xsl:template match="dc:date">
-        <xsl:choose>
-            <xsl:when test="starts-with(., '19')">
-                <originInfo><dateCreated><xsl:apply-templates select="substring(., 1, string-length(.) -10)"/></dateCreated></originInfo>
-            </xsl:when>
-        </xsl:choose>
+        <originInfo><dateCreated><xsl:copy-of select="substring(., 1, string-length(.) -10)"></xsl:copy-of></dateCreated></originInfo>
     </xsl:template>
     
     <!-- subject(s) -->

--- a/XSLT/tsudctomods.xsl
+++ b/XSLT/tsudctomods.xsl
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    version="2.0" xmlns="http://www.loc.gov/mods/v3">
+    
+    <!-- output settings -->
+    <xsl:output encoding="UTF-8" method="xml" omit-xml-declaration="yes" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+    
+    <!-- identity transform -->
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- normalize all the text! -->
+    <xsl:template match="text()">
+        <xsl:value-of select="normalize-space(.)"/>
+    </xsl:template>
+    
+    <!-- match metadata -->
+    <xsl:template match="oai_dc:dc">
+        <!-- match the document root and return a MODS record -->
+        <mods xmlns="http://www.loc.gov/mods/v3" version="3.5"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+            
+            <!-- title -->
+            <xsl:apply-templates select="dc:title"/>
+            
+            <!-- identifier -->
+            <xsl:apply-templates select="dc:identifier"/>
+            
+            <!-- abstract or thumbnail -->
+            <xsl:apply-templates select="dc:description"/>
+            
+            <!-- creator -->
+            <xsl:apply-templates select="dc:creator"/>
+            
+            <!-- originInfo> -->
+            <xsl:apply-templates select="dc:date"/>
+            
+            <!-- subject(s) -->
+            <xsl:apply-templates select="dc:subject"/>
+            
+            <!-- relatedItem -->
+            <xsl:apply-templates select="dc:source"/>
+            
+            <!-- publisher or recordContentSource -->
+            <recordInfo><recordContentSource>Tennessee State University</recordContentSource></recordInfo>
+            
+            <!-- rights or accessCondition -->
+            <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
+            
+        </mods>
+    </xsl:template>
+    
+    <!-- title -->
+    <xsl:template match="dc:title">
+        <titleInfo><title><xsl:apply-templates/></title></titleInfo>
+    </xsl:template>
+    
+    <!-- identifier / object URL / typeOfResource based off collection -->
+    <xsl:template match='dc:identifier'>
+        <xsl:choose>
+            <xsl:when test="matches(., '[0-9]$')">
+                <location>
+                    <url usage="primary" access="object in context"><xsl:apply-templates/></url>
+                </location>
+            </xsl:when>
+            <xsl:when test="contains(., 'library-digital-collections/')">
+                <typeOfResource>still image</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(., 'catalogues/')">
+                <typeOfResource>text</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(., 'yearbooks/')">
+                <typeOfResource>text</typeOfResource>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- abstract or thumbnail -->
+    <xsl:template match="dc:description">
+        <xsl:choose>
+            <xsl:when test="starts-with(., 'https://')">
+                <location>
+                    <url access="preview"><xsl:apply-templates/></url>
+                </location>
+            </xsl:when>
+            <xsl:otherwise>
+                <abstract><xsl:apply-templates/></abstract>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- creator -->
+    <xsl:template match="dc:creator">
+        <name>
+            <namePart><xsl:apply-templates/></namePart>
+            <role>
+                <roleTerm authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+            </role>
+        </name>
+    </xsl:template>
+    
+    <!-- originInfo -->
+    <xsl:template match="dc:date">
+        <xsl:choose>
+            <xsl:when test="starts-with(., '19')">
+                <originInfo><dateCreated><xsl:apply-templates select="substring(., 1, string-length(.) -10)"/></dateCreated></originInfo>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- subject(s) -->
+    <!-- for subjects, whether they contain a ';' or not -->
+    <xsl:template match="dc:subject">
+        <xsl:variable name="subj-tokens" select="tokenize(., ';')"/>
+        <xsl:for-each select="$subj-tokens">
+            <xsl:choose>
+                <xsl:when test="ends-with(., ';')">
+                    <subject>
+                        <topic>
+                            <xsl:value-of select="substring(., 1, string-length(.) -1)"/>
+                        </topic>
+                    </subject>
+                </xsl:when>
+                <xsl:otherwise>
+                    <subject>
+                        <topic><xsl:value-of select="normalize-space(.)"/></topic>
+                    </subject>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
+    </xsl:template>
+    
+    <!-- relatedItem -->
+    <xsl:template match="dc:source">
+        <relatedItem displayLabel="Collection" type="host">
+            <titleInfo>
+                <title><xsl:value-of select="normalize-space(.)"/></title>
+            </titleInfo>
+        </relatedItem>
+    </xsl:template>
+    
+    <!-- recordContentSource -->
+    <xsl:template match="dc:publisher">
+        <recordInfo><recordContentSource><xsl:apply-templates/></recordContentSource></recordInfo>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/XSLT/tsudctomods.xsl
+++ b/XSLT/tsudctomods.xsl
@@ -30,11 +30,10 @@
             <!-- title -->
             <xsl:apply-templates select="dc:title"/>
             
-            <!-- identifier -->
-            <xsl:apply-templates select="dc:identifier"/>
-            
-            <!-- abstract or thumbnail -->
-            <xsl:apply-templates select="dc:description"/>
+            <!-- thumbnail and object URL  -->
+            <location>
+            <xsl:apply-templates select="dc:description[starts-with(normalize-space(.), 'https://')] | dc:identifier[starts-with(normalize-space(.), 'https://')]"/>
+            </location>
             
             <!-- creator -->
             <xsl:apply-templates select="dc:creator"/>
@@ -62,39 +61,26 @@
         <titleInfo><title><xsl:apply-templates/></title></titleInfo>
     </xsl:template>
     
-    <!-- identifier / object URL / typeOfResource based off collection -->
-    <xsl:template match='dc:identifier'>
+    <!-- URLs -->
+    <xsl:template match="dc:description | dc:identifier">
         <xsl:choose>
-            <xsl:when test="contains(., 'library-digital-collections/')">
-                <typeOfResource>still image</typeOfResource>
-            </xsl:when>
-            <xsl:when test="contains(., 'catalogues/')">
-                <typeOfResource>text</typeOfResource>
-            </xsl:when>
-            <xsl:when test="contains(., 'yearbooks/')">
-                <typeOfResource>text</typeOfResource>
+            <xsl:when test="ends-with(., '.jpg')">
+                <url access="preview"><xsl:apply-templates/></url>
             </xsl:when>
             <xsl:when test="matches(., '[0-9]$')">
-                <location>
-                    <url usage="primary" access="object in context"><xsl:apply-templates/></url>
-                </location>
+                <url usage="primary" access="object in context"><xsl:apply-templates/></url>
             </xsl:when>
         </xsl:choose>
     </xsl:template>
-    
-    <!-- abstract or thumbnail -->
+     
+    <!-- abstract
     <xsl:template match="dc:description">
         <xsl:choose>
-            <xsl:when test="starts-with(., 'https://')">
-                <location>
-                    <url access="preview"><xsl:apply-templates/></url>
-                </location>
-            </xsl:when>
-            <xsl:otherwise>
+            <xsl:when test="(., '^[A-Z]')">
                 <abstract><xsl:apply-templates/></abstract>
-            </xsl:otherwise>
+            </xsl:when>
         </xsl:choose>
-    </xsl:template>
+    </xsl:template> -->
     
     <!-- creator -->
     <xsl:template match="dc:creator">
@@ -135,6 +121,17 @@
     
     <!-- relatedItem -->
     <xsl:template match="dc:source">
+        <xsl:choose>
+            <xsl:when test="contains(., 'Digital Collections')">
+                <typeOfResource>still image</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(., 'Catalogues')">
+                <typeOfResource>text</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(., 'Yearbooks')">
+                <typeOfResource>text</typeOfResource>
+            </xsl:when>
+        </xsl:choose>
         <relatedItem displayLabel="Collection" type="host">
             <titleInfo>
                 <title><xsl:value-of select="normalize-space(.)"/></title>


### PR DESCRIPTION
**GitHub Issue**: [254](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/254)

* Other Relevant Links (OAI Feeds, DPLA Records, Metadata Mappings, DLTN Documentation, Etc.)

OAI endpoint - [https://digitalscholarship.tnstate.edu/do/oai/](https://digitalscholarship.tnstate.edu/do/oai/)

## What does this Pull Request do?

This PR adds a transform for Tennessee State University's publication:library-digital-collections, publication:yearbooks, and publication:allcatalogues sets. It also adds a small selection of sample data for all three sets in one XML file. 

## How should this be tested?

Check to make sure that all required fields for DPLA are considered in the transform (title, recordContentSource, accessCondition, thumbnail URL, and object URL). Use the sample data to test transform and ensure that values are represented appropriately (no leftover semicolons etc.)

An additional issue is open to deal with adding this content to Repox and testing to make sure all records meet the requirements - [255](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/255)

## Additional Notes:

An email from Xuemei (Sherry) Ge confirmed that TSU is okay with using "Copyright Not Evaluated" as their rights statement for all of the sets. Note that TSU uses "text" as the dc:type value across all of their collections regardless of content. I've added handling based on the identifier so that the publication:library-digital-collections records are given "still image" as a value since the whole collection consists of photographs. If we add new sets from TSU in the future and want a typeOfResource value, we'll need to add to this hardcoded list.
