### PR TITLE
Knox transform march2021

### DIFF
--- a/XSLT/knoxcountydctomods_newsets.xsl
+++ b/XSLT/knoxcountydctomods_newsets.xsl
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/"
-    version="2.0" xmlns="http://www.loc.gov/mods/v3">
+    version="2.0" xmlns="http://www.loc.gov/mods/v3"
+    exclude-result-prefixes="dc oai_dc">
     
     <!-- output settings -->
     <xsl:output encoding="UTF-8" method="xml" omit-xml-declaration="yes" indent="yes"/>

--- a/XSLT/knoxcountydctomods_newsets.xsl
+++ b/XSLT/knoxcountydctomods_newsets.xsl
@@ -88,7 +88,7 @@
     </xsl:template>
     
     <!-- abstract -->
-    <xsl:template match="dc:description">
+    <xsl:template match="dc:description[1]">
         <abstract><xsl:apply-templates/></abstract>
     </xsl:template>
     

--- a/XSLT/knoxp16311coll3dctomods.xsl
+++ b/XSLT/knoxp16311coll3dctomods.xsl
@@ -19,11 +19,11 @@
         <xsl:value-of select="normalize-space(.)"/>
     </xsl:template>
     
+    <xsl:template match="oai_dc:dc[dc:title[contains(., '_')] | dc:identifier[matches(., '^.*\.tif$')]]"/>
+    
     <!-- match metadata -->
     <xsl:template match="oai_dc:dc">
-        <xsl:if test="dc:title[not(contains(., '_'))]">
-            <xsl:if test="dc:identifier[not(matches(., '[.]tif$'))]">
-            <!-- <xsl:if test="dc:identifier[not(ends-with(., '.tif'))]"> -->
+        
         <!-- match the document root and return a MODS record -->
                 <mods xmlns="http://www.loc.gov/mods/v3" version="3.5"
                     xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -60,8 +60,6 @@
                     <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
                     
                 </mods>
-            </xsl:if>
-        </xsl:if>
     </xsl:template>
     
     <!-- title -->
@@ -81,9 +79,6 @@
                     <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
                 </location>
             </xsl:when>
-            <xsl:otherwise>
-                <identifier><xsl:value-of select="normalize-space(.)"/></identifier>
-            </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
     
@@ -104,7 +99,7 @@
     
     <!-- originInfo -->
     <xsl:template match="dc:date">
-        <originInfo><dateCreated><xsl:apply-templates/></dateCreated></originInfo>
+        <originInfo><dateIssued><xsl:apply-templates/></dateIssued></originInfo>
     </xsl:template>
     
     <!-- subject(s) -->

--- a/XSLT/knoxp16311coll3dctomods.xsl
+++ b/XSLT/knoxp16311coll3dctomods.xsl
@@ -51,6 +51,14 @@
                     <!-- form -->
                     <xsl:apply-templates select="dc:type"/>
                     
+                    <!-- recordContentSource -->
+                    <recordInfo>
+                        <recordContentSource>Knox County Public Library</recordContentSource>
+                    </recordInfo>
+                    
+                    <!-- accessCondition -->
+                    <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
+                    
                 </mods>
             </xsl:if>
         </xsl:if>
@@ -128,13 +136,5 @@
         </physicalDescription>
         <typeOfResource>text</typeOfResource>
     </xsl:template>
-    
-    <!-- recordContentSource -->
-    <recordInfo>
-        <recordContentSource>Knox County Public Library</recordContentSource>
-    </recordInfo>
-    
-    <!-- accessCondition -->
-    <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
   
 </xsl:stylesheet>

--- a/XSLT/knoxp16311coll3dctomods.xsl
+++ b/XSLT/knoxp16311coll3dctomods.xsl
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    version="2.0" xmlns="http://www.loc.gov/mods/v3">
+    
+    <!-- output settings -->
+    <xsl:output encoding="UTF-8" method="xml" omit-xml-declaration="yes" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+    
+    <!-- identity transform -->
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- normalize all the text! -->
+    <xsl:template match="text()">
+        <xsl:value-of select="normalize-space(.)"/>
+    </xsl:template>
+    
+    <!-- match metadata -->
+    <xsl:template match="oai_dc:dc">
+        <xsl:if test="dc:title[not(contains(., '_'))]">
+            <xsl:if test="dc:identifier[not(matches(., '[.]tif$'))]">
+            <!-- <xsl:if test="dc:identifier[not(ends-with(., '.tif'))]"> -->
+        <!-- match the document root and return a MODS record -->
+                <mods xmlns="http://www.loc.gov/mods/v3" version="3.5"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+                    
+                    <!-- title -->
+                    <xsl:apply-templates select="dc:title"/>    
+                    
+                    <!-- identifier -->
+                    <xsl:apply-templates select="dc:identifier"/>
+                    
+                    <!-- description (minus transcriptions) -->
+                    <xsl:apply-templates select="dc:description[1]"/>
+                    
+                    <!-- creator -->
+                    <xsl:apply-templates select="dc:creator"/>
+                    
+                    <!-- originInfo> -->
+                    <xsl:apply-templates select="dc:date"/>
+                    
+                    <!-- subject(s) -->
+                    <xsl:apply-templates select="dc:subject"/>
+                    
+                    <!-- form -->
+                    <xsl:apply-templates select="dc:type"/>
+                    
+                </mods>
+            </xsl:if>
+        </xsl:if>
+    </xsl:template>
+    
+    <!-- title -->
+    <xsl:template match="dc:title">
+        <titleInfo>
+            <title><xsl:value-of select="normalize-space(.)"/></title>
+        </titleInfo>
+    </xsl:template>
+    
+    <!-- identifiers -->
+    <xsl:template match='dc:identifier'>
+        <xsl:choose>
+            <xsl:when test="starts-with(., 'http://')">
+                <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
+                <location>
+                    <url usage="primary" access="object in context"><xsl:apply-templates/></url>
+                    <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
+                </location>
+            </xsl:when>
+            <xsl:otherwise>
+                <identifier><xsl:value-of select="normalize-space(.)"/></identifier>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- abstract -->
+    <xsl:template match="dc:description">
+        <abstract><xsl:apply-templates/></abstract>
+    </xsl:template>
+    
+    <!-- contributor -->
+    <xsl:template match="dc:creator">
+        <name>
+            <namePart><xsl:apply-templates/></namePart>
+            <role>
+                <roleTerm authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+            </role>
+        </name>
+    </xsl:template>
+    
+    <!-- originInfo -->
+    <xsl:template match="dc:date">
+        <originInfo><dateCreated><xsl:apply-templates/></dateCreated></originInfo>
+    </xsl:template>
+    
+    <!-- subject(s) -->
+    <!-- for subjects, whether they contain a ';' or not -->
+    <xsl:template match="dc:subject">
+        <xsl:variable name="subj-tokens" select="tokenize(., '; ')"/>
+        <xsl:for-each select="$subj-tokens">
+            <xsl:choose>
+                <xsl:when test="ends-with(., ';')">
+                    <subject>
+                        <topic>
+                            <xsl:value-of select="substring(., 1, string-length(.) -1)"/>
+                        </topic>
+                    </subject>
+                </xsl:when>
+                <xsl:otherwise>
+                    <subject>
+                        <topic><xsl:value-of select="normalize-space(.)"/></topic>
+                    </subject>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
+    </xsl:template>
+    
+    <!-- typeOfResource -->
+    <xsl:template match="dc:type">
+        <physicalDescription>
+            <form><xsl:apply-templates/></form>
+        </physicalDescription>
+        <typeOfResource>text</typeOfResource>
+    </xsl:template>
+    
+    <!-- recordContentSource -->
+    <recordInfo>
+        <recordContentSource>Knox County Public Library</recordContentSource>
+    </recordInfo>
+    
+    <!-- accessCondition -->
+    <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
+  
+</xsl:stylesheet>


### PR DESCRIPTION
**GitHub Issue**: [March Ingest sets for Knox County Public Library #260 ](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/260)
**Jira Issue**: [DPLA-255](https://jirautk.atlassian.net/browse/DPLA-255)

Other Relevant Links (OAI Feeds, DPLA Records, Metadata Mappings, DLTN Documentation, Etc.) -  
- [p16311coll3](http://cdm16311.contentdm.oclc.org/oai/oai.php?verb=ListRecords&metadataPrefix=oai_dc&set=p16311coll3)
- [p265301coll8](http://cdm16311.contentdm.oclc.org/oai/oai.php?verb=ListRecords&metadataPrefix=oai_dc&set=p265301coll8)
- [p15136coll3](http://cdm16311.contentdm.oclc.org/oai/oai.php?verb=ListRecords&metadataPrefix=oai_dc&set=p15136coll3)
- [p15136coll4](http://cdm16311.contentdm.oclc.org/oai/oai.php?verb=ListRecords&metadataPrefix=oai_dc&set=p15136coll4)

## What does this Pull Request do?

This PR adds a transform for four Knoxville County Public Library sets. These sets contain metadata for the following collections: Knoxville College Archives, Women's Suffrage, George F. Barber, and Selected Materials from the McClung Historical Collection. 

## What's new?

A transform was added to address these sets. Note that it excludes multiple description elements (since the second element contains transcriptions in some cases). There also are a few dates with the value of "unknown" which have been excluded. typeOfResource values have been derived from text values within dc:type. No attempt has been made to define rights beyond "Copyright Not Evaluated."

## How should this be tested?

Use the attached sample data to see if the returned records contain the elements required by DPLA (title, source, thumbnail link, link to object in context, accessCondition).

[knoxcountysample.txt](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/files/6092015/knoxcountysample.txt)

## Interested parties

@CanOfBees @markpbaggett 
