### PR TITLE
Cbu

### DIFF
--- a/XSLT/christianbrothersuniversitydctomods.xsl
+++ b/XSLT/christianbrothersuniversitydctomods.xsl
@@ -60,7 +60,9 @@
             <xsl:apply-templates select="dc:type"/>
             
             <!-- recordContentSource -->
-            <xsl:apply-templates select="dc:publisher"/>
+            <recordInfo>
+                <recordContentSource>Christian Brothers University</recordContentSource>
+            </recordInfo>
             
             <!-- accessCondition -->
             <xsl:apply-templates select="dc:rights"/>
@@ -161,13 +163,6 @@
     <!-- typeOfResource -->
     <xsl:template match="dc:type">
         <typeOfResource><xsl:value-of select="replace(lower-case(.), ';', '')"/></typeOfResource>
-    </xsl:template>
-    
-    <!-- recordContentSource -->
-    <xsl:template match="dc:publisher"> 
-        <recordInfo>
-            <recordContentSource><xsl:apply-templates/></recordContentSource>
-        </recordInfo>
     </xsl:template>
     
     <!-- accessCondition -->

--- a/XSLT/christianbrothersuniversitydctomods.xsl
+++ b/XSLT/christianbrothersuniversitydctomods.xsl
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    version="2.0" xmlns="http://www.loc.gov/mods/v3"
+    exclude-result-prefixes="dc oai_dc">
+
+    <!-- output settings -->
+    <xsl:output encoding="UTF-8" method="xml" omit-xml-declaration="yes" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+    
+    <!-- identity transform -->
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- normalize all the text! -->
+    <xsl:template match="text()">
+        <xsl:value-of select="normalize-space(.)"/>
+    </xsl:template>
+    
+    <!-- match metadata -->
+    <xsl:template match="oai_dc:dc">
+    
+        <!-- match the document root and return a MODS record -->
+        <mods xmlns="http://www.loc.gov/mods/v3" version="3.5"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+            
+            <!-- title -->
+            <xsl:apply-templates select="dc:title"/>  
+            
+            <!-- identifier -->
+            <xsl:apply-templates select="dc:identifier"/>
+            
+            <!-- description -->
+            <xsl:apply-templates select="dc:description"/>
+            
+            <!-- creator -->
+            <xsl:apply-templates select="dc:creator"/>
+            
+            <!-- date -->
+            <xsl:apply-templates select="dc:date"/>
+            
+            <!-- geographic> -->
+            <xsl:apply-templates select="dc:coverage"/>
+            
+            <!-- subject(s) -->
+            <xsl:apply-templates select="dc:subject"/>
+            
+            <!-- form -->
+            <xsl:apply-templates select="dc:format"/>
+            
+            <!-- typeOfResource -->
+            <xsl:apply-templates select="dc:type"/>
+            
+            <!-- recordContentSource -->
+            <xsl:apply-templates select="dc:publisher"/>
+            
+            <!-- accessCondition -->
+            <xsl:apply-templates select="dc:rights"/>
+            
+        </mods>
+    </xsl:template>
+    
+    <!-- title -->
+    <xsl:template match="dc:title">
+        <titleInfo>
+            <title><xsl:value-of select="normalize-space(.)"/></title>
+        </titleInfo>
+    </xsl:template>
+    
+    <!-- identifiers -->
+    <xsl:template match='dc:identifier'>
+        <xsl:choose>
+            <xsl:when test="starts-with(., 'http://')">
+                <xsl:variable name="identifier-preview-url" select="replace(., '/cdm/ref', '/utils/getthumbnail')"/>
+                <location>
+                    <url usage="primary" access="object in context"><xsl:apply-templates/></url>
+                    <url access="preview"><xsl:value-of select="$identifier-preview-url"/></url>
+                </location>
+            </xsl:when>
+            <xsl:otherwise>
+                <identifier><xsl:value-of select="normalize-space(.)"/></identifier>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- abstract -->
+    <xsl:template match="dc:description[1]">
+        <abstract><xsl:apply-templates/></abstract>
+    </xsl:template>
+    
+    <!-- creator -->
+    <xsl:template match="dc:creator">
+        <name>
+            <namePart><xsl:apply-templates/></namePart>
+            <role>
+                <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/cre">Creator</roleTerm>
+            </role>
+        </name>
+    </xsl:template>
+
+    <!-- originInfo -->
+    <xsl:template match="dc:date">
+        <originInfo><dateCreated><xsl:apply-templates/></dateCreated></originInfo>
+    </xsl:template>
+    
+    <!-- form -->
+    <xsl:template match="dc:format">
+        <physicalDescription>
+            <form><xsl:value-of select="lower-case(.)"/></form>
+        </physicalDescription>
+    </xsl:template>
+
+    <!-- geographic -->
+    <xsl:template match="dc:coverage">
+        <subject><geographic><xsl:apply-templates/></geographic></subject>
+    </xsl:template>
+    
+    <!-- subject(s) -->
+    <!-- for subjects, whether they contain a ';' or ',' or not -->
+    <xsl:template match="dc:subject">
+        <xsl:variable name="subj-tokens" select="tokenize(., '; ')"/>
+        <xsl:for-each select="$subj-tokens">
+            <xsl:variable name="subj-tokens" select="tokenize(., ', ')"/>
+            <xsl:for-each select="$subj-tokens">
+                <xsl:choose>
+                    <xsl:when test="ends-with(., ';')">
+                        <subject>
+                            <topic>
+                                <xsl:value-of select="substring(., 1, string-length(.) -1)"/>
+                            </topic>
+                        </subject>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <subject>
+                            <topic><xsl:value-of select="normalize-space(.)"/></topic>
+                        </subject>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:for-each>
+        </xsl:for-each>
+    </xsl:template>
+    
+    <!-- typeOfResource -->
+    <xsl:template match="dc:type">
+        <typeOfResource><xsl:value-of select="replace(lower-case(.), ';', '')"/></typeOfResource>
+    </xsl:template>
+    
+    <!-- recordContentSource -->
+    <xsl:template match="dc:publisher"> 
+        <recordInfo>
+            <recordContentSource><xsl:apply-templates/></recordContentSource>
+        </recordInfo>
+    </xsl:template>
+    
+    <!-- accessCondition -->
+    <xsl:template match='dc:rights'>
+        <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/XSLT/christianbrothersuniversitydctomods.xsl
+++ b/XSLT/christianbrothersuniversitydctomods.xsl
@@ -41,6 +41,9 @@
             <!-- creator -->
             <xsl:apply-templates select="dc:creator"/>
             
+            <!-- contributor -->
+            <xsl:apply-templates select="dc:contributor"/>
+            
             <!-- date -->
             <xsl:apply-templates select="dc:date"/>
             
@@ -102,6 +105,16 @@
             </role>
         </name>
     </xsl:template>
+    
+    <!-- contributor -->
+    <xsl:template match="dc:contributor">
+        <name>
+            <namePart><xsl:apply-templates/></namePart>
+            <role>
+                <roleTerm authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/ctb">Contributor</roleTerm>
+            </role>
+        </name>
+    </xsl:template>
 
     <!-- originInfo -->
     <xsl:template match="dc:date">
@@ -159,6 +172,7 @@
     
     <!-- accessCondition -->
     <xsl:template match='dc:rights'>
+        <accessCondition type="local rights statement">While CBU may house an item, it does not necessarily hold the copyright on the item, nor may it be able to determine if the item is still protected under copyright law. Users are solely responsible for determining the existence of such instances and for obtaining any other permissions and paying associated fees that may be necessary for the intended use. Any image from the library's collection must cite as the source: Brother I. Leo O'Donnell Archives, Plough Library, Christian Brothers University. For all requests, please contact the Archives at archives@cbu.edu.</accessCondition>
         <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
     </xsl:template>
 


### PR DESCRIPTION
**GitHub Issue**: [267](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/267)
**Jira Issue**: [DPLA-263](https://jirautk.atlassian.net/browse/DPLA-263)

* OAI - http://cdm15916.contentdm.oclc.org/oai/oai.php 

## What does this Pull Request do?

This PR adds a transform for Christian Brothers University's content. They currently are adding everything to one set - p15916coll1

## What's new?

An in-depth description of the intended changes made by this PR. Technical details and possible side effects.

* Added transform to do X
* Remove transform to do y
* Modified transform to do x
* Could this change impact any other transforms?

## How should this be tested?

A description of what steps someone could take to:

* Does the transform validate in Oxygen using the Saxon 8.7 processor
* Using sample XML code [cbu_test.txt](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/files/6947600/cbu_test.txt), does the pull request doe what is intended
* If you run a full Schema validation on the feed the transform(s) applies to(using Variety.js and DLTN Metadata QA), does every record have:
	* a titleInfo/title
	* a location/url
	* an accessCondition
	* a provider name

## Additional Notes:

Talking with Kay and Deborah at CBU, they wanted two rights values to appear. They are comfortable with me adding "Copyright Not Evaluated" for everything, but they also wanted to have a local rights statement with contact information for the archive. Looking at [DPLA's rights documentation](https://docs.google.com/document/d/1aInokOIIsgf-B4iMTXU33qYN5B2jA3s91KgWoh7DZ7Q/edit) and at our sets for Rhodes, it looks like this local statement
 should go in accessCondition[@type="local rights statement"]. Please double check my logic on this to confirm that both will show up in DPLA. I believe the two statements are not in conflict.

## Interested parties

@CanOfBees @markpbaggett 
