### PR TITLE
Edit transform to include archival collection in output.

### DIFF
--- a/XSLT/chattpubdctermstomods.xsl
+++ b/XSLT/chattpubdctermstomods.xsl
@@ -52,6 +52,9 @@
                     <recordContentSource>Chattanooga Public Library</recordContentSource>
                 </recordInfo>
                 
+                <!-- collection title -->
+                <xsl:apply-templates select="dcterms:isPartOf"></xsl:apply-templates>
+                
                 <!-- rights -->
                 <xsl:apply-templates select="dcterms:rights"/>
                 
@@ -112,6 +115,15 @@
                 </topic>
             </xsl:otherwise>
         </xsl:choose>
+    </xsl:template>
+    
+    <!-- collection title -->
+    <xsl:template match='dcterms:isPartOf'>
+        <relatedItem displayLabel="Collection" type="host">
+            <titleInfo>
+                <title><xsl:apply-templates/></title>
+            </titleInfo>
+        </relatedItem>
     </xsl:template>
     
     <!-- accessCondition -->


### PR DESCRIPTION
**GitHub Issue**: [302](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/302)

**Other Relevant Links**
Chattanooga Public OAI - https://collections.chattlibrary.org/oai

## What does this Pull Request do?

This PR edits the existing transform for Chattanooga Public Library so that the collection title is included.  Jessica Sedgwick wanted this metadata included as it provides important context.

## What's new?

The transform works with dcterms:isPartOf and puts the values into mods:relatedItem

## How should this be tested?

Does this transform do what is intended (include the collection title in MODS)?

## Additional Notes:

The December ingest will be taking place on Dec. 18th. I'm planning to apply this by then.
