### PR TITLE
Add handling for additional form terms for new sets.

### DIFF
--- a/XSLT/montgomerycountyarchivesdctomods.xsl
+++ b/XSLT/montgomerycountyarchivesdctomods.xsl
@@ -159,6 +159,24 @@
                     <form>records (documents)</form>
                 </physicalDescription>
              </xsl:when>
+             <xsl:when test="contains(., 'correspondence')">
+                <typeOfResource>text</typeOfResource>
+                <physicalDescription>
+                    <form>correspondence</form>
+                </physicalDescription>
+            </xsl:when>
+            <xsl:when test="contains(., 'programs')">
+                <typeOfResource>text</typeOfResource>
+                <physicalDescription>
+                    <form>programs (documents)</form>
+                </physicalDescription>
+            </xsl:when>
+            <xsl:when test="contains(., 'publications')">
+                <typeOfResource>text</typeOfResource>
+                <physicalDescription>
+                    <form>publications (documents)</form>
+                </physicalDescription>
+            </xsl:when>
              <xsl:when test="contains(.,'photographs') or contains(., 'Photographs')">
                 <typeOfResource>still image</typeOfResource>
                 <physicalDescription>


### PR DESCRIPTION
Associated GitHub Issues: [Issue 310](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/310) 

Relevant Links (OAI Feeds, DPLA Records, Metadata Mappings, DLTN Documentation, Etc.)
*MCA OAI-PMH - https://cdm17128.contentdm.oclc.org/oai/oai.php

## What does this Pull Request do?

This PR adds handling to deal with new form terms present in Montgomery County Archives' metadata for the June 2024 DPLA ingest. 

## How should this be tested?

Use the [mcatestdata.txt](https://github.com/user-attachments/files/15570087/mcatestdata.txt) in Oxygen (change extension to .xml) with the edited transform to see if the form terms and typeOfResource values show up correctly.

## Additional Notes

@mkaljns - I'm putting you on this PR as I don't know who else to include. The changes are pretty minimal. I'll add you to the DLTN organization so you can have access to the code? I think I can convert you to an outside collaborator once the invite is accepted.
