### PR TITLE
Add transform.

### DIFF
--- a/XSLT/umemphisdsc2MODS.xsl
+++ b/XSLT/umemphisdsc2MODS.xsl
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    version="2.0" xmlns="http://www.loc.gov/mods/v3"
+    exclude-result-prefixes="dc oai_dc">
+    
+    <!-- output settings -->
+    <xsl:output encoding="UTF-8" method="xml" omit-xml-declaration="yes" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+    
+    <!-- identity transform -->
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- normalize all the text! -->
+    <xsl:template match="text()">
+        <xsl:value-of select="normalize-space(.)"/>
+    </xsl:template>
+    
+    <!-- match metadata -->
+    <xsl:template match="oai_dc:dc">
+        
+        <!-- match the document root and return a MODS record -->
+        <mods xmlns="http://www.loc.gov/mods/v3" version="3.5"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+            
+            <!-- title -->
+            <xsl:apply-templates select="dc:title"/>  
+            
+            <xsl:if test="dc:identifier|dc:description">
+                <location>
+                    <xsl:for-each select="dc:identifier[starts-with(., 'https:')]">
+                        <url usage="primary" access="object in context"><xsl:value-of select="normalize-space(.)"/></url>
+                    </xsl:for-each>
+                    <xsl:for-each select="dc:description[starts-with(., 'https:')]">
+                        <url access="preview"><xsl:value-of select="normalize-space(.)"/></url>
+                    </xsl:for-each>
+                </location>
+            </xsl:if>
+            
+            <!-- typeOfResource -->
+            <xsl:apply-templates select="dc:type"/>
+            
+            <!-- recordContentSource -->
+            <recordInfo>
+                <recordContentSource>University of Memphis. Special Collections</recordContentSource>
+            </recordInfo>
+            
+            <!-- accessCondition -->
+            <xsl:apply-templates select="dc:rights"/>
+            
+        </mods>
+    </xsl:template>
+    
+    <!-- title -->
+    <xsl:template match="dc:title">
+        <titleInfo>
+            <title><xsl:value-of select="normalize-space(.)"/></title>
+        </titleInfo>
+    </xsl:template>
+    
+    <!-- typeOfResource -->
+    <xsl:template match="dc:type">
+        <xsl:choose>
+            <xsl:when test="contains(., 'Image')">
+                <typeOfResource>still image</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(.,'Audio')">
+                <typeOfResource>sound recording-nonmusical</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(.,'Text')">
+                <typeOfResource>text</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(.,'Book')">
+                <typeOfResource>text</typeOfResource>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- accessCondition -->
+    <xsl:template match='dc:rights'>
+        <xsl:variable name="vRights" select="normalize-space(.)"/>
+        <xsl:choose>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/CNE/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/NoC-US/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/NoC-US/1.0/">No Copyright - United States</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/InC/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/UND/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/UND/1.0/">Copyright Undetermined</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/NKC/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/NKC/1.0/">No Known Copyright</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/InC-EDU/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC-EDU/1.0/">In Copyright - Educational Use Permitted</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/InC-NC/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC-NC/1.0/">In Copyright - Non-Commercial Use Permitted</accessCondition>
+            </xsl:when>
+            <xsl:otherwise>
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/XSLT/umemphisdsctoMODS.xsl
+++ b/XSLT/umemphisdsctoMODS.xsl
@@ -32,11 +32,18 @@
             <!-- title -->
             <xsl:apply-templates select="dc:title"/>  
             
-            <!-- abstract and thumbnail -->
-            <xsl:apply-templates select="dc:description"/>
+            <xsl:apply-templates select="dc:description[1]"/>
             
-            <!-- identifier -->
-            <xsl:apply-templates select="dc:identifier"/>
+            <xsl:if test="dc:identifier|dc:description">
+                <location>
+                    <xsl:for-each select="dc:identifier[starts-with(., 'https:')]">
+                        <url usage="primary" access="object in context"><xsl:value-of select="normalize-space(.)"/></url>
+                    </xsl:for-each>
+                    <xsl:for-each select="dc:description[starts-with(., 'https:')]">
+                        <url access="preview"><xsl:value-of select="normalize-space(.)"/></url>
+                    </xsl:for-each>
+                </location>
+            </xsl:if>
             
             <!-- typeOfResource -->
             <xsl:apply-templates select="dc:type"/>
@@ -62,26 +69,6 @@
     <!-- abstract -->
     <xsl:template match="dc:description[1]">
         <abstract><xsl:value-of select="substring(., 1, string-length(.))"/></abstract>
-    </xsl:template>
-    
-    <!-- URLs (description & identifier) -->
-    <xsl:template match='dc:identifier'>
-        <xsl:choose>
-            <xsl:when test="starts-with(., 'https:')">
-                <location><url usage="primary" access="object in context"><xsl:apply-templates/></url></location>
-            </xsl:when>
-            <xsl:otherwise>
-                <identifier><xsl:value-of select="normalize-space(.)"/></identifier>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:template>
-    
-    <xsl:template match='dc:description'>
-        <xsl:choose>
-            <xsl:when test="starts-with(., 'https:')">
-                <location><url access="preview"><xsl:apply-templates/></url></location>
-            </xsl:when>
-        </xsl:choose>
     </xsl:template>
     
     <!-- typeOfResource -->

--- a/XSLT/umemphisdsctoMODS.xsl
+++ b/XSLT/umemphisdsctoMODS.xsl
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    version="2.0" xmlns="http://www.loc.gov/mods/v3"
+    exclude-result-prefixes="dc oai_dc">
+    
+    <!-- output settings -->
+    <xsl:output encoding="UTF-8" method="xml" omit-xml-declaration="yes" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+    
+    <!-- identity transform -->
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- normalize all the text! -->
+    <xsl:template match="text()">
+        <xsl:value-of select="normalize-space(.)"/>
+    </xsl:template>
+    
+    <!-- match metadata -->
+    <xsl:template match="oai_dc:dc">
+        
+        <!-- match the document root and return a MODS record -->
+        <mods xmlns="http://www.loc.gov/mods/v3" version="3.5"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+            
+            <!-- title -->
+            <xsl:apply-templates select="dc:title"/>  
+            
+            <!-- abstract and thumbnail -->
+            <xsl:apply-templates select="dc:description"/>
+            
+            <!-- identifier -->
+            <xsl:apply-templates select="dc:identifier"/>
+            
+            <!-- typeOfResource -->
+            <xsl:apply-templates select="dc:type"/>
+            
+            <!-- recordContentSource -->
+            <recordInfo>
+                <recordContentSource>University of Memphis. Special Collections</recordContentSource>
+            </recordInfo>
+            
+            <!-- accessCondition -->
+            <xsl:apply-templates select="dc:rights"/>
+            
+        </mods>
+    </xsl:template>
+    
+    <!-- title -->
+    <xsl:template match="dc:title">
+        <titleInfo>
+            <title><xsl:value-of select="normalize-space(.)"/></title>
+        </titleInfo>
+    </xsl:template>
+    
+    <!-- abstract -->
+    <xsl:template match="dc:description[1]">
+        <abstract><xsl:value-of select="substring(., 1, string-length(.))"/></abstract>
+    </xsl:template>
+    
+    <!-- URLs (description & identifier) -->
+    <xsl:template match='dc:identifier'>
+        <xsl:choose>
+            <xsl:when test="starts-with(., 'https:')">
+                <location><url usage="primary" access="object in context"><xsl:apply-templates/></url></location>
+            </xsl:when>
+            <xsl:otherwise>
+                <identifier><xsl:value-of select="normalize-space(.)"/></identifier>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match='dc:description'>
+        <xsl:choose>
+            <xsl:when test="starts-with(., 'https:')">
+                <location><url access="preview"><xsl:apply-templates/></url></location>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- typeOfResource -->
+    <xsl:template match="dc:type">
+        <xsl:choose>
+            <xsl:when test="contains(., 'Image')">
+                <typeOfResource>still image</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(.,'Audio')">
+                <typeOfResource>sound recording-nonmusical</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(.,'Text')">
+                <typeOfResource>text</typeOfResource>
+            </xsl:when>
+            <xsl:when test="contains(.,'Book')">
+                <typeOfResource>text</typeOfResource>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- accessCondition -->
+    <xsl:template match='dc:rights'>
+        <xsl:variable name="vRights" select="normalize-space(.)"/>
+        <xsl:choose>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/CNE/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/NoC-US/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/NoC-US/1.0/">No Copyright - United States</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/InC/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/UND/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/UND/1.0/">Copyright Undetermined</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/NKC/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/NKC/1.0/">No Known Copyright</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/InC-EDU/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC-EDU/1.0/">In Copyright - Educational Use Permitted</accessCondition>
+            </xsl:when>
+            <xsl:when test="contains($vRights, 'http://rightsstatements.org/vocab/InC-NC/1.0/')">
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC-NC/1.0/">In Copyright - Non-Commercial Use Permitted</accessCondition>
+            </xsl:when>
+            <xsl:otherwise>
+                <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/CNE/1.0/">Copyright Not Evaluated</accessCondition>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
**GitHub Issue**: [327](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/327)

* Other Relevant Links (OAI Feeds, DPLA Records, Metadata Mappings, DLTN Documentation, Etc.)
* OAI for UMemphis: https://digitalcommons.memphis.edu/do/oai

## What does this Pull Request do?

This adds a transform to change University of Memphis's data to MODS to be contributed to DPLA for the December 2025 ingest.

## How should this be tested?

Use the sample test data to see if the transform works
[UMemphisTestRecords.xml](https://github.com/user-attachments/files/24264825/UMemphisTestRecords.xml). Note that you'll need to change the extension to .xml

See if the resulting XML is valid and that each record includes the following five fields:

- title
- rights
- provider (recordInfo/recordContentSource)
- link to object (location/url)
- link to thumbnail

## Notes

The main issue seems to be that the link to object and link to thumbnail need to be within the same `<location>' element (rather than separate ones) to pass testing. Because the thumbnail link is within the description element and the link to the object is in identifier, this is more challenging to achieve than normal. The output should look like this:

```
<location>
       <url usage="primary" access="object in context">https://digitalcommons.memphis.edu/speccoll-mss-petertaylor1/7</url>
       <url usage="preview">https://digitalcommons.memphis.edu/speccoll-mss-petertaylor1/1006/thumbnail.jpg</url>
</location>
```
