### PR TITLE
Chatt pub oral history edit

### DIFF
--- a/XSLT/chattpubdctermstomods.xsl
+++ b/XSLT/chattpubdctermstomods.xsl
@@ -74,11 +74,6 @@
         <xsl:choose>
             <xsl:when test="contains($vThumb, 'localhistory')">
                 <url usage="primary" access="object in context"><xsl:apply-templates/></url>
-                <xsl:choose>
-                    <xsl:when test="contains($vThumb, 'https://collections.chattlibrary.org/s/localhistory/item/836194')">
-                        <url access="preview">https://upload.wikimedia.org/wikipedia/commons/5/55/GDocs.png</url>
-                    </xsl:when>
-                </xsl:choose>
             </xsl:when>
         </xsl:choose>
         <xsl:choose>

--- a/XSLT/chattpubdctermstomods.xsl
+++ b/XSLT/chattpubdctermstomods.xsl
@@ -74,6 +74,11 @@
         <xsl:choose>
             <xsl:when test="contains($vThumb, 'localhistory')">
                 <url usage="primary" access="object in context"><xsl:apply-templates/></url>
+                <xsl:choose>
+                    <xsl:when test="contains($vThumb, 'https://collections.chattlibrary.org/s/localhistory/item/836194')">
+                        <url access="preview">https://upload.wikimedia.org/wikipedia/commons/5/55/GDocs.png</url>
+                    </xsl:when>
+                </xsl:choose>
             </xsl:when>
         </xsl:choose>
         <xsl:choose>

--- a/XSLT/chattpubdctermstomods.xsl
+++ b/XSLT/chattpubdctermstomods.xsl
@@ -77,7 +77,10 @@
         </xsl:choose>
         <xsl:choose>
             <xsl:when test="ends-with(., '.pdf')">
-                <url access="preview">https://upload.wikimedia.org/wikipedia/commons/thumb/6/6c/PDF_icon.svg/1024px-PDF_icon.svg.png</url>
+                <url access="preview">https://upload.wikimedia.org/wikipedia/commons/4/47/Pdf_337946.png?utm_source=commons.wikimedia.org&utm_campaign=index&utm_content=original</url>
+            </xsl:when>
+            <xsl:when test="ends-with(., '.mp3')">
+                <url access="preview">https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Bootstrap_filetype-mp3.svg/1280px-Bootstrap_filetype-mp3.svg.png</url>
             </xsl:when>
             <xsl:when test="ends-with(., '.jpg')">
                 <xsl:variable name="preview-url" select="replace(., 'original', 'medium')"/>

--- a/XSLT/chattpubdctermstomods.xsl
+++ b/XSLT/chattpubdctermstomods.xsl
@@ -77,7 +77,7 @@
         </xsl:choose>
         <xsl:choose>
             <xsl:when test="ends-with(., '.pdf')">
-                <url access="preview">https://upload.wikimedia.org/wikipedia/commons/4/47/Pdf_337946.png?utm_source=commons.wikimedia.org&utm_campaign=index&utm_content=original</url>
+                <url access="preview">https://upload.wikimedia.org/wikipedia/commons/4/47/Pdf_337946.png</url>
             </xsl:when>
             <xsl:when test="ends-with(., '.mp3')">
                 <url access="preview">https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Bootstrap_filetype-mp3.svg/1280px-Bootstrap_filetype-mp3.svg.png</url>

--- a/XSLT/chattpubdctermstomods.xsl
+++ b/XSLT/chattpubdctermstomods.xsl
@@ -36,7 +36,7 @@
                 <xsl:apply-templates select="dcterms:title"/>
                 
                 <!-- identifier -->
-                <location><xsl:apply-templates select="dcterms:identifier"/></location>
+                <location><xsl:apply-templates select="dcterms:identifier[@xsi:type='dcterms:URI']"/></location>
                 
                 <!-- description -->
                 <xsl:apply-templates select="dcterms:description"/>
@@ -70,23 +70,29 @@
       
     <!-- identifiers -->
     <xsl:template match='dcterms:identifier'>
+        <xsl:variable name="vThumb" select="normalize-space(.)"/>
         <xsl:choose>
-            <xsl:when test="contains(., 'localhistory')">
+            <xsl:when test="contains($vThumb, 'localhistory')">
                 <url usage="primary" access="object in context"><xsl:apply-templates/></url>
             </xsl:when>
         </xsl:choose>
         <xsl:choose>
-            <xsl:when test="ends-with(., '.pdf')">
+        <xsl:when test="ends-with($vThumb, '.pdf')">
                 <url access="preview">https://upload.wikimedia.org/wikipedia/commons/4/47/Pdf_337946.png</url>
             </xsl:when>
-            <xsl:when test="ends-with(., '.mp3')">
-                <url access="preview">https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Bootstrap_filetype-mp3.svg/1280px-Bootstrap_filetype-mp3.svg.png</url>
-            </xsl:when>
-            <xsl:when test="ends-with(., '.jpg')">
+            <xsl:when test="ends-with($vThumb, '.jpg')">
                 <xsl:variable name="preview-url" select="replace(., 'original', 'medium')"/>
                 <url access="preview"><xsl:value-of select="$preview-url"/></url>
             </xsl:when>
+            <xsl:when test="ends-with($vThumb, '.mp3')">
+                <xsl:choose>
+                    <xsl:when test="position()=2">
+                        <url access="preview">https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Bootstrap_filetype-mp3.svg/1280px-Bootstrap_filetype-mp3.svg.png</url>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:when>
         </xsl:choose>
+
     </xsl:template>
     
     <!-- description -->


### PR DESCRIPTION
Related issue: https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/330

## What does this Pull Request do?

Chattanooga Public Library wanted to update its records for the June 2026 ingest. Since their last ingest in 2023, a number of oral history resources have been added to their collections. These records do not have any thumbnail images, so a generic thumbnail for mp3 files needed to be hard coded into the transform.

## What's new?

Adds logic to deal with audio only files so that they have a thumbnail image (required for DPLA sharing)

## How should this be tested?

Run the XSLT against this test file (change extension to .xml).
[ChattPubOH.txt](https://github.com/user-attachments/files/27963726/ChattPubOH.txt)


## Additional Notes:

This code has already been implemented for the June ingest. Check and harvest was run and no errors were found.
